### PR TITLE
Phase 4: Migrate onboarding endpoint to OnboardingController (#203)

### DIFF
--- a/src/__tests__/authProfile.test.ts
+++ b/src/__tests__/authProfile.test.ts
@@ -6,7 +6,6 @@ import authRoutes from "../routes/authRoutes";
 import { withTransaction } from "../repo/db";
 import * as userRepo from "../repo/userRepo";
 import * as sessionRepo from "../repo/sessionRepo";
-import * as taskRepo from "../repo/taskRepo";
 import { getRelevantTaskWhere } from "../repo/taskAssignmentRepo";
 import { syncUserTaskAssignments } from "../services/taskAssignmentService";
 
@@ -211,101 +210,3 @@ describe("/api/auth/profile", () => {
   });
 });
 
-describe("POST /api/onboarding/tasks", () => {
-  beforeEach(() => {
-    vi.clearAllMocks();
-    vi.mocked(getRelevantTaskWhere).mockReturnValue({ mockedWhere: true } as never);
-    vi.mocked(taskRepo.findOnboardingPreviewTasks).mockResolvedValue([]);
-  });
-
-  it("returns 400 for invalid boolean and enum fields", async () => {
-    const invalidIsEU = await request(app)
-      .post("/api/onboarding/tasks")
-      .send({ isEU: "yes" })
-      .set("Content-Type", "application/json");
-    expect(invalidIsEU.status).toBe(400);
-    expect(invalidIsEU.body.error).toContain("Invalid isEU");
-
-    const invalidChildren = await request(app)
-      .post("/api/onboarding/tasks")
-      .send({ hasChildren: "no" })
-      .set("Content-Type", "application/json");
-    expect(invalidChildren.status).toBe(400);
-    expect(invalidChildren.body.error).toContain("Invalid hasChildren");
-
-    const invalidEmployment = await request(app)
-      .post("/api/onboarding/tasks")
-      .send({ employmentStatus: "CONTRACTOR" })
-      .set("Content-Type", "application/json");
-    expect(invalidEmployment.status).toBe(400);
-    expect(invalidEmployment.body.error).toContain("Invalid employmentStatus");
-
-    expect(taskRepo.findOnboardingPreviewTasks).not.toHaveBeenCalled();
-  });
-
-  it("returns 400 for invalid date payloads", async () => {
-    const invalidArrivalDate = await request(app)
-      .post("/api/onboarding/tasks")
-      .send({ arrivalDate: "2026-02-30" })
-      .set("Content-Type", "application/json");
-    expect(invalidArrivalDate.status).toBe(400);
-    expect(invalidArrivalDate.body.error).toContain("Invalid arrivalDate");
-
-    const invalidPlannedDate = await request(app)
-      .post("/api/onboarding/tasks")
-      .send({ plannedArrivalDate: "not-a-date" })
-      .set("Content-Type", "application/json");
-    expect(invalidPlannedDate.status).toBe(400);
-    expect(invalidPlannedDate.body.error).toContain("Invalid plannedArrivalDate");
-
-    expect(taskRepo.findOnboardingPreviewTasks).not.toHaveBeenCalled();
-  });
-
-  it("delegates to findOnboardingPreviewTasks and returns minimal task data", async () => {
-    vi.mocked(taskRepo.findOnboardingPreviewTasks).mockResolvedValueOnce([
-      {
-        id: "task-1",
-        title: "Register with police",
-        shortDescription: "Complete police registration",
-        category: "ARRIVAL",
-        sortOrder: 20,
-      },
-    ] as never);
-
-    const response = await request(app)
-      .post("/api/onboarding/tasks")
-      .send({
-        isEU: true,
-        hasChildren: false,
-        employmentStatus: "EMPLOYED",
-        arrivalDate: "2026-03-01",
-        plannedArrivalDate: "2026-02-25",
-      })
-      .set("Content-Type", "application/json");
-
-    expect(response.status).toBe(200);
-    expect(response.body).toEqual([
-      {
-        id: "task-1",
-        title: "Register with police",
-        shortDescription: "Complete police registration",
-        category: "ARRIVAL",
-        sortOrder: 20,
-      },
-    ]);
-
-    expect(getRelevantTaskWhere).toHaveBeenCalledWith(
-      expect.objectContaining({
-        id: "onboarding-preview",
-        isEU: true,
-        hasChildren: false,
-        employmentStatus: "EMPLOYED",
-        arrivalDate: new Date("2026-03-01T00:00:00.000Z"),
-        plannedArrivalDate: new Date("2026-02-25T00:00:00.000Z"),
-      }),
-      expect.any(Date),
-    );
-
-    expect(taskRepo.findOnboardingPreviewTasks).toHaveBeenCalledWith({ mockedWhere: true });
-  });
-});

--- a/src/__tests__/onboardingController.test.ts
+++ b/src/__tests__/onboardingController.test.ts
@@ -1,0 +1,147 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import request from "supertest";
+import express from "express";
+import { RegisterRoutes } from "../generated/routes";
+import { tsoaErrorHandler } from "../middleware/tsoaErrorHandler";
+import { errorLogger } from "../middleware/errorLogger";
+import { requestLogger } from "../middleware/requestLogger";
+import * as taskRepo from "../repo/taskRepo";
+import { getRelevantTaskWhere } from "../repo/taskAssignmentRepo";
+
+vi.mock("../repo/taskRepo", () => ({
+  findOnboardingPreviewTasks: vi.fn(),
+}));
+
+vi.mock("../repo/taskAssignmentRepo", () => ({
+  getRelevantTaskWhere: vi.fn(),
+}));
+
+const createTestApp = () => {
+  const app = express();
+  app.use(express.json());
+  app.use(requestLogger);
+  RegisterRoutes(app);
+  app.use(tsoaErrorHandler);
+  app.use(errorLogger);
+  return app;
+};
+
+describe("POST /api/onboarding/tasks", () => {
+  let app: express.Express;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(getRelevantTaskWhere).mockReturnValue({ mockedWhere: true } as never);
+    vi.mocked(taskRepo.findOnboardingPreviewTasks).mockResolvedValue([]);
+    app = createTestApp();
+  });
+
+  it("returns 422 when boolean fields have invalid types", async () => {
+    const invalidIsEU = await request(app)
+      .post("/api/onboarding/tasks")
+      .send({ isEU: "yes" })
+      .set("Content-Type", "application/json");
+    expect(invalidIsEU.status).toBe(422);
+    expect(invalidIsEU.body.message).toBe("Validation Failed");
+    expect(invalidIsEU.body.details).toBeDefined();
+
+    const invalidChildren = await request(app)
+      .post("/api/onboarding/tasks")
+      .send({ hasChildren: "no" })
+      .set("Content-Type", "application/json");
+    expect(invalidChildren.status).toBe(422);
+    expect(invalidChildren.body.message).toBe("Validation Failed");
+
+    expect(taskRepo.findOnboardingPreviewTasks).not.toHaveBeenCalled();
+  });
+
+  it("returns 422 for an unsupported employmentStatus enum value", async () => {
+    const invalidEmployment = await request(app)
+      .post("/api/onboarding/tasks")
+      .send({ employmentStatus: "CONTRACTOR" })
+      .set("Content-Type", "application/json");
+    expect(invalidEmployment.status).toBe(422);
+    expect(invalidEmployment.body.message).toBe("Validation Failed");
+    expect(invalidEmployment.body.details).toBeDefined();
+
+    expect(taskRepo.findOnboardingPreviewTasks).not.toHaveBeenCalled();
+  });
+
+  it("returns 400 for invalid date payloads", async () => {
+    const invalidArrivalDate = await request(app)
+      .post("/api/onboarding/tasks")
+      .send({ arrivalDate: "2026-02-30" })
+      .set("Content-Type", "application/json");
+    expect(invalidArrivalDate.status).toBe(400);
+    expect(invalidArrivalDate.body.error).toContain("Invalid arrivalDate");
+
+    const invalidPlannedDate = await request(app)
+      .post("/api/onboarding/tasks")
+      .send({ plannedArrivalDate: "not-a-date" })
+      .set("Content-Type", "application/json");
+    expect(invalidPlannedDate.status).toBe(400);
+    expect(invalidPlannedDate.body.error).toContain("Invalid plannedArrivalDate");
+
+    expect(taskRepo.findOnboardingPreviewTasks).not.toHaveBeenCalled();
+  });
+
+  it("delegates to findOnboardingPreviewTasks and returns minimal task data", async () => {
+    vi.mocked(taskRepo.findOnboardingPreviewTasks).mockResolvedValueOnce([
+      {
+        id: "task-1",
+        title: "Register with police",
+        shortDescription: "Complete police registration",
+        category: "ARRIVAL",
+        sortOrder: 20,
+      },
+    ] as never);
+
+    const response = await request(app)
+      .post("/api/onboarding/tasks")
+      .send({
+        isEU: true,
+        hasChildren: false,
+        employmentStatus: "EMPLOYED",
+        arrivalDate: "2026-03-01",
+        plannedArrivalDate: "2026-02-25",
+      })
+      .set("Content-Type", "application/json");
+
+    expect(response.status).toBe(200);
+    expect(response.body).toEqual([
+      {
+        id: "task-1",
+        title: "Register with police",
+        shortDescription: "Complete police registration",
+        category: "ARRIVAL",
+        sortOrder: 20,
+      },
+    ]);
+
+    expect(getRelevantTaskWhere).toHaveBeenCalledWith(
+      expect.objectContaining({
+        id: "onboarding-preview",
+        isEU: true,
+        hasChildren: false,
+        employmentStatus: "EMPLOYED",
+        arrivalDate: new Date("2026-03-01T00:00:00.000Z"),
+        plannedArrivalDate: new Date("2026-02-25T00:00:00.000Z"),
+      }),
+      expect.any(Date),
+    );
+
+    expect(taskRepo.findOnboardingPreviewTasks).toHaveBeenCalledWith({ mockedWhere: true });
+  });
+
+  it("returns 500 when findOnboardingPreviewTasks throws", async () => {
+    vi.mocked(taskRepo.findOnboardingPreviewTasks).mockRejectedValueOnce(new Error("db down"));
+
+    const response = await request(app)
+      .post("/api/onboarding/tasks")
+      .send({ isEU: false })
+      .set("Content-Type", "application/json");
+
+    expect(response.status).toBe(500);
+    expect(response.body.error).toBe("Failed to fetch onboarding tasks");
+  });
+});

--- a/src/controllers/OnboardingController.ts
+++ b/src/controllers/OnboardingController.ts
@@ -53,6 +53,9 @@ export class OnboardingController {
         plannedArrivalDate: plannedArrivalDate ?? null,
       });
 
+      // Prisma generates TaskCategory as a string-literal union (const object),
+      // while the DTO uses our app-level TS enum. The values are identical at
+      // runtime so the cast is safe, but the two types are nominally incompatible.
       return tasks as OnboardingTaskPreviewDto[];
     } catch (error: unknown) {
       req.logger.error({ err: error, msg: "Failed to fetch onboarding task preview" });

--- a/src/controllers/OnboardingController.ts
+++ b/src/controllers/OnboardingController.ts
@@ -1,0 +1,78 @@
+import { Body, Post, Route, Response, SuccessResponse, Request } from "tsoa";
+import { OnboardingProfileDto } from "../dto/OnboardingDto";
+import * as onboardingService from "../services/onboardingService";
+import { parseDateOnly } from "../lib/dateUtils";
+import { EMPLOYMENT_STATUS_VALUES, EmploymentStatus } from "../types/enums";
+import type { Request as ExpressRequest } from "express";
+
+const EMPLOYMENT_STATUSES = new Set<string>(EMPLOYMENT_STATUS_VALUES);
+
+@Route("onboarding")
+export class OnboardingController {
+  /**
+   * Get a preview of tasks based on user profile.
+   * Public endpoint used during onboarding before account creation.
+   */
+  @Post("tasks")
+  @SuccessResponse("200", "Task preview generated")
+  @Response<{ error: string }>("400", "Validation error")
+  @Response<{ message: string; details: Record<string, unknown> }>("422", "DTO validation failed")
+  @Response<{ error: string }>("500", "Server error")
+  public async getTaskPreview(
+    @Body() body: OnboardingProfileDto,
+    @Request() req: ExpressRequest
+  ): Promise<unknown> {
+    if (
+      body.employmentStatus !== undefined &&
+      body.employmentStatus !== null &&
+      !EMPLOYMENT_STATUSES.has(body.employmentStatus)
+    ) {
+      throw {
+        status: 400,
+        message: "Invalid employmentStatus.",
+      };
+    }
+
+    const arrivalDate = parseDateOnly(body.arrivalDate);
+    if (
+      body.arrivalDate !== undefined &&
+      body.arrivalDate !== null &&
+      arrivalDate === undefined
+    ) {
+      throw {
+        status: 400,
+        message: "Invalid arrivalDate. Must be YYYY-MM-DD or null.",
+      };
+    }
+
+    const plannedArrivalDate = parseDateOnly(body.plannedArrivalDate);
+    if (
+      body.plannedArrivalDate !== undefined &&
+      body.plannedArrivalDate !== null &&
+      plannedArrivalDate === undefined
+    ) {
+      throw {
+        status: 400,
+        message: "Invalid plannedArrivalDate. Must be YYYY-MM-DD or null.",
+      };
+    }
+
+    try {
+      const tasks = await onboardingService.getTaskPreview({
+        isEU: body.isEU ?? null,
+        hasChildren: body.hasChildren ?? null,
+        employmentStatus: (body.employmentStatus ?? null) as EmploymentStatus | null,
+        arrivalDate: arrivalDate ?? null,
+        plannedArrivalDate: plannedArrivalDate ?? null,
+      });
+
+      return tasks;
+    } catch (error: unknown) {
+      req.logger.error({ err: error, msg: "Failed to fetch onboarding task preview" });
+      throw {
+        status: 500,
+        message: "Failed to fetch onboarding tasks",
+      };
+    }
+  }
+}

--- a/src/controllers/OnboardingController.ts
+++ b/src/controllers/OnboardingController.ts
@@ -1,11 +1,9 @@
 import { Body, Post, Route, Response, SuccessResponse, Request } from "tsoa";
-import { OnboardingProfileDto } from "../dto/OnboardingDto";
+import { OnboardingProfileDto, OnboardingTaskPreviewDto } from "../dto/OnboardingDto";
 import * as onboardingService from "../services/onboardingService";
 import { parseDateOnly } from "../lib/dateUtils";
-import { EMPLOYMENT_STATUS_VALUES, EmploymentStatus } from "../types/enums";
+import { EmploymentStatus } from "../types/enums";
 import type { Request as ExpressRequest } from "express";
-
-const EMPLOYMENT_STATUSES = new Set<string>(EMPLOYMENT_STATUS_VALUES);
 
 @Route("onboarding")
 export class OnboardingController {
@@ -21,18 +19,7 @@ export class OnboardingController {
   public async getTaskPreview(
     @Body() body: OnboardingProfileDto,
     @Request() req: ExpressRequest
-  ): Promise<unknown> {
-    if (
-      body.employmentStatus !== undefined &&
-      body.employmentStatus !== null &&
-      !EMPLOYMENT_STATUSES.has(body.employmentStatus)
-    ) {
-      throw {
-        status: 400,
-        message: "Invalid employmentStatus.",
-      };
-    }
-
+  ): Promise<OnboardingTaskPreviewDto[]> {
     const arrivalDate = parseDateOnly(body.arrivalDate);
     if (
       body.arrivalDate !== undefined &&
@@ -66,7 +53,7 @@ export class OnboardingController {
         plannedArrivalDate: plannedArrivalDate ?? null,
       });
 
-      return tasks;
+      return tasks as OnboardingTaskPreviewDto[];
     } catch (error: unknown) {
       req.logger.error({ err: error, msg: "Failed to fetch onboarding task preview" });
       throw {

--- a/src/dto/OnboardingDto.ts
+++ b/src/dto/OnboardingDto.ts
@@ -1,4 +1,4 @@
-import { EmploymentStatus } from "../types/enums";
+import { EmploymentStatus, TaskCategory } from "../types/enums";
 
 export class OnboardingProfileDto {
   /**
@@ -30,4 +30,36 @@ export class OnboardingProfileDto {
    * @example "2024-06-01"
    */
   plannedArrivalDate?: string | null;
+}
+
+export class OnboardingTaskPreviewDto {
+  /**
+   * Task identifier
+   * @example "c3b2a1d0-0000-4000-8000-000000000001"
+   */
+  id!: string;
+
+  /**
+   * Task title
+   * @example "Register with the police"
+   */
+  title!: string;
+
+  /**
+   * Short description shown in previews
+   * @example "Complete your initial police registration within 3 months of arrival."
+   */
+  shortDescription!: string | null;
+
+  /**
+   * Task category used for grouping and ordering
+   * @example "ARRIVAL"
+   */
+  category!: TaskCategory;
+
+  /**
+   * Relative ordering within a category
+   * @example 20
+   */
+  sortOrder!: number;
 }

--- a/src/dto/OnboardingDto.ts
+++ b/src/dto/OnboardingDto.ts
@@ -1,4 +1,4 @@
-import { EmploymentStatus } from "@/types/enums";
+import { EmploymentStatus } from "../types/enums";
 
 export class OnboardingProfileDto {
   /**

--- a/src/generated/routes.ts
+++ b/src/generated/routes.ts
@@ -5,6 +5,8 @@ import type { TsoaRoute } from '@tsoa/runtime';
 import {  fetchMiddlewares, ExpressTemplateService } from '@tsoa/runtime';
 // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
 import { OtpController } from './../controllers/OtpController';
+// WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+import { OnboardingController } from './../controllers/OnboardingController';
 import { expressAuthentication } from './../middleware/tsoaAuthentication';
 // @ts-ignore - no great way to install types from subpackage
 import type { Request as ExRequest, Response as ExResponse, RequestHandler, Router } from 'express';
@@ -52,6 +54,23 @@ const models: TsoaRoute.Models = {
         "properties": {
             "email": {"dataType":"string","required":true,"validators":{"maxLength":{"value":320}}},
             "code": {"dataType":"integer","required":true,"validators":{"minimum":{"value":100000},"maximum":{"value":999999}}},
+        },
+        "additionalProperties": false,
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    "EmploymentStatus": {
+        "dataType": "refEnum",
+        "enums": ["EMPLOYED","SELF_EMPLOYED","UNEMPLOYED","STUDENT","OTHER"],
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    "OnboardingProfileDto": {
+        "dataType": "refObject",
+        "properties": {
+            "isEU": {"dataType":"union","subSchemas":[{"dataType":"boolean"},{"dataType":"enum","enums":[null]}]},
+            "hasChildren": {"dataType":"union","subSchemas":[{"dataType":"boolean"},{"dataType":"enum","enums":[null]}]},
+            "employmentStatus": {"dataType":"union","subSchemas":[{"ref":"EmploymentStatus"},{"dataType":"enum","enums":[null]}]},
+            "arrivalDate": {"dataType":"union","subSchemas":[{"dataType":"string"},{"dataType":"enum","enums":[null]}]},
+            "plannedArrivalDate": {"dataType":"union","subSchemas":[{"dataType":"string"},{"dataType":"enum","enums":[null]}]},
         },
         "additionalProperties": false,
     },
@@ -124,6 +143,37 @@ export function RegisterRoutes(app: Router) {
 
               await templateService.apiHandler({
                 methodName: 'verifyOtp',
+                controller,
+                response,
+                next,
+                validatedArgs,
+                successStatus: 200,
+              });
+            } catch (err) {
+                return next(err);
+            }
+        });
+        // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+        const argsOnboardingController_getTaskPreview: Record<string, TsoaRoute.ParameterSchema> = {
+                body: {"in":"body","name":"body","required":true,"ref":"OnboardingProfileDto"},
+                req: {"in":"request","name":"req","required":true,"dataType":"object"},
+        };
+        app.post('/api/onboarding/tasks',
+            ...(fetchMiddlewares<RequestHandler>(OnboardingController)),
+            ...(fetchMiddlewares<RequestHandler>(OnboardingController.prototype.getTaskPreview)),
+
+            async function OnboardingController_getTaskPreview(request: ExRequest, response: ExResponse, next: any) {
+
+            // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+
+            let validatedArgs: any[] = [];
+            try {
+                validatedArgs = templateService.getValidatedArgs({ args: argsOnboardingController_getTaskPreview, request, response });
+
+                const controller = new OnboardingController();
+
+              await templateService.apiHandler({
+                methodName: 'getTaskPreview',
                 controller,
                 response,
                 next,

--- a/src/generated/routes.ts
+++ b/src/generated/routes.ts
@@ -58,6 +58,23 @@ const models: TsoaRoute.Models = {
         "additionalProperties": false,
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    "TaskCategory": {
+        "dataType": "refEnum",
+        "enums": ["ARRIVAL","IDENTITY_BANKING","HEALTH","TAX_WORK","FAMILY","HOUSING","DRIVING","OTHER"],
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    "OnboardingTaskPreviewDto": {
+        "dataType": "refObject",
+        "properties": {
+            "id": {"dataType":"string","required":true},
+            "title": {"dataType":"string","required":true},
+            "shortDescription": {"dataType":"union","subSchemas":[{"dataType":"string"},{"dataType":"enum","enums":[null]}],"required":true},
+            "category": {"ref":"TaskCategory","required":true},
+            "sortOrder": {"dataType":"double","required":true},
+        },
+        "additionalProperties": false,
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
     "EmploymentStatus": {
         "dataType": "refEnum",
         "enums": ["EMPLOYED","SELF_EMPLOYED","UNEMPLOYED","STUDENT","OTHER"],

--- a/src/generated/swagger.json
+++ b/src/generated/swagger.json
@@ -106,6 +106,56 @@
 				],
 				"type": "object",
 				"additionalProperties": false
+			},
+			"EmploymentStatus": {
+				"enum": [
+					"EMPLOYED",
+					"SELF_EMPLOYED",
+					"UNEMPLOYED",
+					"STUDENT",
+					"OTHER"
+				],
+				"type": "string"
+			},
+			"OnboardingProfileDto": {
+				"properties": {
+					"isEU": {
+						"type": "boolean",
+						"nullable": true,
+						"description": "Is the user from an EU country?",
+						"example": true
+					},
+					"hasChildren": {
+						"type": "boolean",
+						"nullable": true,
+						"description": "Does the user have children?",
+						"example": false
+					},
+					"employmentStatus": {
+						"allOf": [
+							{
+								"$ref": "#/components/schemas/EmploymentStatus"
+							}
+						],
+						"nullable": true,
+						"description": "User's employment status",
+						"example": "EMPLOYED"
+					},
+					"arrivalDate": {
+						"type": "string",
+						"nullable": true,
+						"description": "Arrival date in Norway (YYYY-MM-DD)",
+						"example": "2024-01-15"
+					},
+					"plannedArrivalDate": {
+						"type": "string",
+						"nullable": true,
+						"description": "Planned arrival date (YYYY-MM-DD)",
+						"example": "2024-06-01"
+					}
+				},
+				"type": "object",
+				"additionalProperties": false
 			}
 		},
 		"securitySchemes": {
@@ -337,6 +387,92 @@
 						"application/json": {
 							"schema": {
 								"$ref": "#/components/schemas/VerifyOtpDto"
+							}
+						}
+					}
+				}
+			}
+		},
+		"/onboarding/tasks": {
+			"post": {
+				"operationId": "GetTaskPreview",
+				"responses": {
+					"200": {
+						"description": "Task preview generated",
+						"content": {
+							"application/json": {
+								"schema": {}
+							}
+						}
+					},
+					"400": {
+						"description": "Validation error",
+						"content": {
+							"application/json": {
+								"schema": {
+									"properties": {
+										"error": {
+											"type": "string"
+										}
+									},
+									"required": [
+										"error"
+									],
+									"type": "object"
+								}
+							}
+						}
+					},
+					"422": {
+						"description": "DTO validation failed",
+						"content": {
+							"application/json": {
+								"schema": {
+									"properties": {
+										"details": {
+											"$ref": "#/components/schemas/Record_string.unknown_"
+										},
+										"message": {
+											"type": "string"
+										}
+									},
+									"required": [
+										"details",
+										"message"
+									],
+									"type": "object"
+								}
+							}
+						}
+					},
+					"500": {
+						"description": "Server error",
+						"content": {
+							"application/json": {
+								"schema": {
+									"properties": {
+										"error": {
+											"type": "string"
+										}
+									},
+									"required": [
+										"error"
+									],
+									"type": "object"
+								}
+							}
+						}
+					}
+				},
+				"description": "Get a preview of tasks based on user profile.\nPublic endpoint used during onboarding before account creation.",
+				"security": [],
+				"parameters": [],
+				"requestBody": {
+					"required": true,
+					"content": {
+						"application/json": {
+							"schema": {
+								"$ref": "#/components/schemas/OnboardingProfileDto"
 							}
 						}
 					}

--- a/src/generated/swagger.json
+++ b/src/generated/swagger.json
@@ -107,6 +107,59 @@
 				"type": "object",
 				"additionalProperties": false
 			},
+			"TaskCategory": {
+				"enum": [
+					"ARRIVAL",
+					"IDENTITY_BANKING",
+					"HEALTH",
+					"TAX_WORK",
+					"FAMILY",
+					"HOUSING",
+					"DRIVING",
+					"OTHER"
+				],
+				"type": "string"
+			},
+			"OnboardingTaskPreviewDto": {
+				"properties": {
+					"id": {
+						"type": "string",
+						"description": "Task identifier",
+						"example": "c3b2a1d0-0000-4000-8000-000000000001"
+					},
+					"title": {
+						"type": "string",
+						"description": "Task title",
+						"example": "Register with the police"
+					},
+					"shortDescription": {
+						"type": "string",
+						"nullable": true,
+						"description": "Short description shown in previews",
+						"example": "Complete your initial police registration within 3 months of arrival."
+					},
+					"category": {
+						"$ref": "#/components/schemas/TaskCategory",
+						"description": "Task category used for grouping and ordering",
+						"example": "ARRIVAL"
+					},
+					"sortOrder": {
+						"type": "number",
+						"format": "double",
+						"description": "Relative ordering within a category",
+						"example": 20
+					}
+				},
+				"required": [
+					"id",
+					"title",
+					"shortDescription",
+					"category",
+					"sortOrder"
+				],
+				"type": "object",
+				"additionalProperties": false
+			},
 			"EmploymentStatus": {
 				"enum": [
 					"EMPLOYED",
@@ -401,7 +454,12 @@
 						"description": "Task preview generated",
 						"content": {
 							"application/json": {
-								"schema": {}
+								"schema": {
+									"items": {
+										"$ref": "#/components/schemas/OnboardingTaskPreviewDto"
+									},
+									"type": "array"
+								}
 							}
 						}
 					},

--- a/src/routes/authRoutes.ts
+++ b/src/routes/authRoutes.ts
@@ -4,7 +4,6 @@ import { authenticateSession } from "../middleware/authMiddleware";
 import { logger } from "../lib/logger";
 import { parseDateOnly } from "../lib/dateUtils";
 import * as authService from "../services/authService";
-import * as onboardingService from "../services/onboardingService";
 
 const router = Router();
 const EMPLOYMENT_STATUSES = new Set<string>(EMPLOYMENT_STATUS_VALUES);
@@ -81,22 +80,6 @@ const parseOnboardingProfilePayload = (body: unknown): OnboardingProfileParseRes
     },
   };
 };
-
-router.post("/onboarding/tasks", async (req, res) => {
-  const parsed = parseOnboardingProfilePayload(req.body);
-  if (parsed.error) {
-    return res.status(parsed.error.status).json(parsed.error.body);
-  }
-
-  try {
-    const tasks = await onboardingService.getTaskPreview(parsed.value);
-
-    return res.status(200).json(tasks);
-  } catch (error: unknown) {
-    logger.error({ err: error, msg: "Failed to fetch onboarding task preview" });
-    return res.status(500).json({ error: "Failed to fetch onboarding tasks" });
-  }
-});
 
 router.get("/auth/session", authenticateSession, (req, res) => {
   return res.status(200).json({


### PR DESCRIPTION
Moves POST /api/onboarding/tasks from the Express authRoutes handler to a tsoa-decorated OnboardingController. tsoa now owns DTO type and enum validation (422), while the controller still enforces YYYY-MM-DD date-format validation (400).

Also switches OnboardingDto's EmploymentStatus import to a relative path so tsoa can resolve it.
