### PR TITLE
Phase 8: final cleanup and documentation (tsoa migration)

### DIFF
--- a/README.md
+++ b/README.md
@@ -364,6 +364,8 @@ The API uses [tsoa](https://tsoa-community.github.io/docs/) for type-safe routin
 
 Visit `http://localhost:3001/api-docs` to explore the API interactively.
 
+> Swagger UI is only served when `API_DOCS_ENABLED=true` is set. The default `.env.example` enables it for local development.
+
 ### Adding Endpoints
 
 See [docs/API.md](docs/API.md) for a detailed guide on adding new endpoints.

--- a/README.md
+++ b/README.md
@@ -356,6 +356,32 @@ All logs from the same request share the same `requestId`, making it easy to tra
 | `npm run test:all:parallel`    | Run unit and E2E tests in parallel                       |
 | `npm run test:ci`              | CI mode: unit coverage + E2E                             |
 
+## API Documentation
+
+The API uses [tsoa](https://tsoa-community.github.io/docs/) for type-safe routing and auto-generated OpenAPI specification.
+
+### Swagger UI
+
+Visit `http://localhost:3001/api-docs` to explore the API interactively.
+
+### Adding Endpoints
+
+See [docs/API.md](docs/API.md) for a detailed guide on adding new endpoints.
+
+### Regenerating Routes
+
+Routes are auto-generated from controller decorators:
+
+```bash
+npm run tsoa:build
+```
+
+This creates:
+- `src/generated/routes.ts` — Route registration
+- `src/generated/swagger.json` — OpenAPI 3.0 spec
+
+---
+
 ## API Endpoints
 
 All endpoints are served by the Express backend at port 3001. Next.js API routes in `src/app/api/` proxy to them transparently.

--- a/docs/API.md
+++ b/docs/API.md
@@ -1,0 +1,132 @@
+# API Development Guide
+
+## Adding a New Endpoint
+
+### 1. Create a DTO
+
+Define request/response types in `src/dto/`:
+
+```typescript
+// src/dto/ExampleDto.ts
+export class CreateExampleDto {
+  /**
+   * Example field
+   * @example "value"
+   * @minLength 1
+   * @maxLength 100
+   */
+  name!: string;
+}
+```
+
+### 2. Create or Update a Controller
+
+```typescript
+// src/controllers/ExampleController.ts
+import { Body, Post, Route, Security, Request } from "tsoa";
+import { CreateExampleDto } from "@/dto/ExampleDto";
+import type { Request as ExpressRequest } from "express";
+
+@Route("examples")
+export class ExampleController {
+  @Post()
+  @Security("cookie_auth") // Add this for protected endpoints
+  public async create(
+    @Body() body: CreateExampleDto,
+    @Request() req: ExpressRequest
+  ): Promise<any> {
+    // Access authenticated user
+    const userId = req.user!.id;
+
+    // Access logger
+    req.logger.info({ msg: "Creating example" });
+
+    // Call service layer
+    const result = await exampleService.create(body, userId);
+
+    return result;
+  }
+}
+```
+
+### 3. Regenerate Routes
+
+```bash
+npm run tsoa:build
+```
+
+### 4. Test
+
+- Visit `/api-docs` to see the new endpoint in Swagger UI
+- Write unit tests in `src/__tests__/`
+- Test manually via Swagger UI or curl
+
+---
+
+## Common Patterns
+
+### Protected Endpoint
+
+```typescript
+@Get("protected")
+@Security("cookie_auth")
+public async protectedRoute(@Request() req: ExpressRequest) {
+  const user = req.user!; // Available after authentication
+  // ...
+}
+```
+
+### Public Endpoint
+
+```typescript
+@Post("public")
+public async publicRoute(@Body() body: SomeDto) {
+  // No @Security decorator = public
+  // ...
+}
+```
+
+### Error Handling
+
+```typescript
+if (!result.success) {
+  throw {
+    status: 404,
+    message: "Resource not found",
+  };
+}
+```
+
+### Path Parameters
+
+```typescript
+@Get("{id}")
+public async getById(@Path() id: string) {
+  // ...
+}
+```
+
+### Query Parameters
+
+```typescript
+@Get()
+public async list(@Query() limit?: number) {
+  // ...
+}
+```
+
+---
+
+## OpenAPI Annotations
+
+Use JSDoc tags in DTOs for OpenAPI schema enrichment:
+
+| Tag | Purpose |
+|---|---|
+| `@example` | Example value shown in Swagger UI |
+| `@minLength` / `@maxLength` | String length constraints |
+| `@minimum` / `@maximum` | Number range constraints |
+| `@isInt` | Integer validation |
+| `@pattern` | Regex pattern constraint |
+
+These annotations appear in Swagger UI and are included in the generated `swagger.json`.

--- a/docs/API.md
+++ b/docs/API.md
@@ -24,7 +24,7 @@ export class CreateExampleDto {
 ```typescript
 // src/controllers/ExampleController.ts
 import { Body, Post, Route, Security, Request } from "tsoa";
-import { CreateExampleDto } from "@/dto/ExampleDto";
+import { CreateExampleDto } from "../dto/ExampleDto";
 import type { Request as ExpressRequest } from "express";
 
 @Route("examples")
@@ -57,7 +57,7 @@ npm run tsoa:build
 
 ### 4. Test
 
-- Visit `/api-docs` to see the new endpoint in Swagger UI
+- Visit `/api-docs` to see the new endpoint in Swagger UI (requires `API_DOCS_ENABLED=true`)
 - Write unit tests in `src/__tests__/`
 - Test manually via Swagger UI or curl
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -97,3 +97,63 @@ Centralises Prisma error code handling. The `handleDatabaseError` function maps 
 ### Handling new Prisma error codes
 
 Add a new `case` to `handleDatabaseError` in `src/repo/errors.ts`.
+
+---
+
+## Routing & Controllers (tsoa)
+
+The API uses **tsoa** for type-safe, decorator-based routing with auto-generated OpenAPI specification.
+
+### Controller Structure
+
+Controllers live in `src/controllers/` and use tsoa decorators:
+
+```typescript
+@Route("tasks")
+export class TaskController {
+  @Get("personalized")
+  @Security("cookie_auth")
+  public async getUserTasks(@Request() req: ExpressRequest): Promise<Task[]> {
+    // ...
+  }
+}
+```
+
+### Route Generation
+
+Routes are generated at build time by running `npm run tsoa:build`, which creates:
+- `src/generated/routes.ts` — Express route registration
+- `src/generated/swagger.json` — OpenAPI 3.0 specification
+
+These files are gitignored and regenerated on every build.
+
+### Authentication
+
+Protected endpoints use `@Security("cookie_auth")` which triggers the authentication handler in `src/middleware/tsoaAuthentication.ts`. This handler reuses the existing session validation logic from `sessionRepo`.
+
+### Validation
+
+Request validation is handled by:
+1. **TypeScript types** — Compile-time type checking via DTOs
+2. **tsoa runtime validation** — Validates request body matches DTO shape
+3. **Custom validation** — Additional business logic in controller methods
+
+### DTOs
+
+Data Transfer Objects in `src/dto/` define request/response shapes:
+- `OtpDto.ts` — OTP generation and verification
+- `OnboardingDto.ts` — Onboarding profile
+- `AuthDto.ts` — Auth and profile updates
+- `TaskDto.ts` — Task creation and status updates
+
+DTOs use JSDoc comments for OpenAPI schema generation.
+
+### Adding a New Endpoint
+
+1. Create or update a controller in `src/controllers/`
+2. Add tsoa decorators (`@Get`, `@Post`, etc.)
+3. Define request/response DTOs in `src/dto/`
+4. Run `npm run tsoa:build` to regenerate routes
+5. Test via Swagger UI at `/api-docs`
+
+See `docs/API.md` for detailed examples.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -125,7 +125,7 @@ Routes are generated at build time by running `npm run tsoa:build`, which create
 - `src/generated/routes.ts` — Express route registration
 - `src/generated/swagger.json` — OpenAPI 3.0 specification
 
-These files are gitignored and regenerated on every build.
+These files are **committed to the repository** (unlike the Prisma-generated client) because the app imports `routes.ts` at runtime. Regenerate them after any controller change.
 
 ### Authentication
 
@@ -154,6 +154,6 @@ DTOs use JSDoc comments for OpenAPI schema generation.
 2. Add tsoa decorators (`@Get`, `@Post`, etc.)
 3. Define request/response DTOs in `src/dto/`
 4. Run `npm run tsoa:build` to regenerate routes
-5. Test via Swagger UI at `/api-docs`
+5. Test via Swagger UI at `/api-docs` (requires `API_DOCS_ENABLED=true`)
 
 See `docs/API.md` for detailed examples.

--- a/src/routes/authRoutes.ts
+++ b/src/routes/authRoutes.ts
@@ -1,7 +1,0 @@
-import { Router } from "express";
-
-// Auth endpoints have been migrated to AuthController (tsoa).
-// This file is kept as a placeholder and will be removed once all routes are on tsoa.
-const router = Router();
-
-export default router;


### PR DESCRIPTION
## Summary

- Deletes `src/routes/authRoutes.ts` — the empty placeholder left after auth endpoints were migrated to `AuthController` (tsoa). No code imports this file.
- Adds a **Routing & Controllers (tsoa)** section to `docs/ARCHITECTURE.md` covering controller structure, route generation, authentication, validation, DTOs, and how to add new endpoints.
- Creates `docs/API.md` — a practical guide for adding new endpoints including DTOs, controller patterns, common patterns (protected/public endpoints, path/query params, error handling), and OpenAPI annotations.
- Adds an **API Documentation** section to `README.md` with Swagger UI URL, link to `docs/API.md`, and `tsoa:build` usage.

## Test plan

- [x] `npm run lint` — 0 errors
- [x] `npm run test:unit` — 286 tests pass (2 skipped integration suites require a live DB, pre-existing)
- [x] `npm run build` — production build succeeds

Closes #207

Made with [Cursor](https://cursor.com)