### PR TITLE
chore: upgrade @getbrevo/brevo v4 → v5

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.1.0",
       "hasInstallScript": true,
       "dependencies": {
-        "@getbrevo/brevo": "^4.0.1",
+        "@getbrevo/brevo": "^5",
         "@prisma/client": "^6.19.2",
         "@radix-ui/react-label": "^2.1.8",
         "@radix-ui/react-slot": "^1.2.4",
@@ -1036,9 +1036,9 @@
       }
     },
     "node_modules/@getbrevo/brevo": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/@getbrevo/brevo/-/brevo-4.0.1.tgz",
-      "integrity": "sha512-U1xOsr5e7pfRTdngrt9VWmPV8SQD/LayTOp55/Wnb4aW33IkBWypDJ8jOpQtxn6xL4t8aBw1thRisvQY4+/Edw==",
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/@getbrevo/brevo/-/brevo-5.0.4.tgz",
+      "integrity": "sha512-wN4mHE6O0Pb/d/Dh3E4MAm2zCHbLLUcFF8/wgwTeMPy9KzHBYLu7S/nsJbzd0AWL09MHn8vwue8ULL9YOzluOQ==",
       "engines": {
         "node": ">=18.0.0"
       }

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "test:quick": "vitest run --reporter=dot && playwright test --reporter=dot"
   },
   "dependencies": {
-    "@getbrevo/brevo": "^4.0.1",
+    "@getbrevo/brevo": "^5",
     "@prisma/client": "^6.19.2",
     "@radix-ui/react-label": "^2.1.8",
     "@radix-ui/react-slot": "^1.2.4",

--- a/src/__tests__/services/email/brevoProvider.test.ts
+++ b/src/__tests__/services/email/brevoProvider.test.ts
@@ -54,7 +54,7 @@ describe('BrevoProvider', () => {
     beforeEach(async () => {
       const { BrevoClient } = await import('@getbrevo/brevo');
       const mockClient = new BrevoClient({ apiKey: mockApiKey });
-      mockSendTransacEmail = (mockClient.transactionalEmails as { sendTransacEmail: ReturnType<typeof vi.fn> }).sendTransacEmail;
+      mockSendTransacEmail = (mockClient.transactionalEmails as unknown as { sendTransacEmail: ReturnType<typeof vi.fn> }).sendTransacEmail;
     });
 
     it('should send email successfully with minimal options', async () => {
@@ -270,7 +270,7 @@ describe('BrevoProvider', () => {
     beforeEach(async () => {
       const { BrevoClient } = await import('@getbrevo/brevo');
       const mockClient = new BrevoClient({ apiKey: mockApiKey });
-      mockSendTransacEmail = (mockClient.transactionalEmails as { sendTransacEmail: ReturnType<typeof vi.fn> }).sendTransacEmail;
+      mockSendTransacEmail = (mockClient.transactionalEmails as unknown as { sendTransacEmail: ReturnType<typeof vi.fn> }).sendTransacEmail;
     });
 
     it('should parse email with name correctly', async () => {

--- a/src/__tests__/services/email/brevoProvider.test.ts
+++ b/src/__tests__/services/email/brevoProvider.test.ts
@@ -52,9 +52,8 @@ describe('BrevoProvider', () => {
     let mockSendTransacEmail: ReturnType<typeof vi.fn>;
 
     beforeEach(async () => {
-      const { BrevoClient } = await import('@getbrevo/brevo');
-      const mockClient = new BrevoClient({ apiKey: mockApiKey });
-      mockSendTransacEmail = (mockClient.transactionalEmails as unknown as { sendTransacEmail: ReturnType<typeof vi.fn> }).sendTransacEmail;
+      const { __mockSendTransacEmail } = await import('@getbrevo/brevo') as unknown as { __mockSendTransacEmail: ReturnType<typeof vi.fn> };
+      mockSendTransacEmail = __mockSendTransacEmail;
     });
 
     it('should send email successfully with minimal options', async () => {
@@ -268,9 +267,8 @@ describe('BrevoProvider', () => {
     let mockSendTransacEmail: ReturnType<typeof vi.fn>;
 
     beforeEach(async () => {
-      const { BrevoClient } = await import('@getbrevo/brevo');
-      const mockClient = new BrevoClient({ apiKey: mockApiKey });
-      mockSendTransacEmail = (mockClient.transactionalEmails as unknown as { sendTransacEmail: ReturnType<typeof vi.fn> }).sendTransacEmail;
+      const { __mockSendTransacEmail } = await import('@getbrevo/brevo') as unknown as { __mockSendTransacEmail: ReturnType<typeof vi.fn> };
+      mockSendTransacEmail = __mockSendTransacEmail;
     });
 
     it('should parse email with name correctly', async () => {

--- a/src/__tests__/services/email/integration.test.ts
+++ b/src/__tests__/services/email/integration.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, beforeAll, afterAll, vi } from 'vitest';
+import type { EmailService } from '../../../services/email';
 
 const originalEnv = process.env;
 
@@ -23,7 +24,7 @@ vi.mock('@getbrevo/brevo', () => {
 });
 
 describe('Email Service Integration', () => {
-  let emailService: { sendEmail: (options: unknown) => Promise<unknown> };
+  let emailService: EmailService;
 
   beforeAll(async () => {
     process.env.EMAIL_PROVIDER = 'brevo';
@@ -42,7 +43,7 @@ describe('Email Service Integration', () => {
     it('should be able to send email', async () => {
       const { BrevoClient } = await import('@getbrevo/brevo');
       const mockClient = new BrevoClient({ apiKey: 'test' });
-      const mockSendTransacEmail = (mockClient.transactionalEmails as { sendTransacEmail: ReturnType<typeof vi.fn> }).sendTransacEmail;
+      const mockSendTransacEmail = (mockClient.transactionalEmails as unknown as { sendTransacEmail: ReturnType<typeof vi.fn> }).sendTransacEmail;
 
       mockSendTransacEmail.mockResolvedValue({ messageId: 'integration-test-id' });
 
@@ -67,7 +68,7 @@ describe('Email Service Integration', () => {
     ])('propagates provider error: %s', async (errorMessage) => {
       const { BrevoClient } = await import('@getbrevo/brevo');
       const mockClient = new BrevoClient({ apiKey: 'test' });
-      const mockSendTransacEmail = (mockClient.transactionalEmails as { sendTransacEmail: ReturnType<typeof vi.fn> }).sendTransacEmail;
+      const mockSendTransacEmail = (mockClient.transactionalEmails as unknown as { sendTransacEmail: ReturnType<typeof vi.fn> }).sendTransacEmail;
 
       mockSendTransacEmail.mockRejectedValue(new Error(errorMessage));
 

--- a/src/__tests__/services/email/integration.test.ts
+++ b/src/__tests__/services/email/integration.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, beforeAll, afterAll, vi } from 'vitest';
 import type { EmailService } from '../../../services/email';
 
-const originalEnv = { ...process.env };
+const originalEnv = process.env;
 
 vi.mock('@getbrevo/brevo', () => {
   const mockSendTransacEmail = vi.fn();
@@ -27,6 +27,7 @@ describe('Email Service Integration', () => {
   let emailService: EmailService;
 
   beforeAll(async () => {
+    process.env = { ...originalEnv };
     process.env.EMAIL_PROVIDER = 'brevo';
     process.env.EMAIL_FROM = 'test@example.com';
     process.env.BREVO_API_KEY = 'test-api-key';
@@ -36,7 +37,7 @@ describe('Email Service Integration', () => {
   });
 
   afterAll(() => {
-    process.env = { ...originalEnv };
+    process.env = originalEnv;
   });
 
   describe('emailService singleton', () => {

--- a/src/__tests__/services/email/integration.test.ts
+++ b/src/__tests__/services/email/integration.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, beforeAll, afterAll, vi } from 'vitest';
 import type { EmailService } from '../../../services/email';
 
-const originalEnv = process.env;
+const originalEnv = { ...process.env };
 
 vi.mock('@getbrevo/brevo', () => {
   const mockSendTransacEmail = vi.fn();
@@ -36,7 +36,7 @@ describe('Email Service Integration', () => {
   });
 
   afterAll(() => {
-    process.env = originalEnv;
+    process.env = { ...originalEnv };
   });
 
   describe('emailService singleton', () => {


### PR DESCRIPTION
## Summary

- Bumps `@getbrevo/brevo` from `4.0.1` to `5.0.4` (latest v5 release)
- v5 is a focused type-correction release — no API methods renamed or removed
- Updates test files to use double-cast (`as unknown as`) to satisfy stricter `TransactionalEmailsClient` types introduced in v5
- Fixes `integration.test.ts` to type `emailService` as `EmailService` instead of a loose structural type

## Test plan

- [x] `npm run lint` — passes with 0 errors
- [x] `npm run test:unit` — 327/327 tests pass, no regressions
- [x] `npm run build` — build succeeds

Made with [Cursor](https://cursor.com)