### PR TITLE
[Admin] Phase 1 — Schema: AdminUser and AdminSession models

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -25,6 +25,18 @@ DATABASE_URL=postgresql://postgres:REPLACE_ME_with_a_strong_password@postgres:54
 # Generate one with: node -e "console.log(require('crypto').randomBytes(32).toString('hex'))"
 SESSION_COOKIE_SECRET=REPLACE_ME_with_a_long_random_secret
 
+# ─── Admin portal ─────────────────────────────────────────────────────────────
+# URL path segment for the admin portal (no leading slash, e.g. "secure-portal").
+# Avoid obvious names like "admin" or "adminlogin".
+ADMIN_PATH=REPLACE_ME_with_an_obscure_path_segment
+
+# Secret used to sign admin session cookies — MUST differ from SESSION_COOKIE_SECRET.
+# Generate one with: node -e "console.log(require('crypto').randomBytes(32).toString('hex'))"
+ADMIN_SESSION_COOKIE_SECRET=REPLACE_ME_with_a_different_long_random_secret
+
+# Email address of the initial admin user created by the seed script.
+ADMIN_SEED_EMAIL=admin@example.com
+
 # ─── Email ───────────────────────────────────────────────────────────────────
 # Supported providers: brevo
 EMAIL_PROVIDER=brevo

--- a/.env.example
+++ b/.env.example
@@ -35,7 +35,8 @@ ADMIN_PATH=REPLACE_ME_with_an_obscure_path_segment
 ADMIN_SESSION_COOKIE_SECRET=REPLACE_ME_with_a_different_long_random_secret
 
 # Email address of the initial admin user created by the seed script.
-ADMIN_SEED_EMAIL=admin@example.com
+# Leave unset to skip admin seeding (safe default).
+ADMIN_SEED_EMAIL=
 
 # ─── Email ───────────────────────────────────────────────────────────────────
 # Supported providers: brevo

--- a/prisma/migrations/20260512213700_add_admin_user_and_session/migration.sql
+++ b/prisma/migrations/20260512213700_add_admin_user_and_session/migration.sql
@@ -1,0 +1,35 @@
+-- CreateTable
+CREATE TABLE "AdminUser" (
+    "id" UUID NOT NULL DEFAULT gen_random_uuid(),
+    "email" VARCHAR(320) NOT NULL,
+    "name" VARCHAR(255),
+    "createdAt" TIMESTAMPTZ(6) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "AdminUser_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "AdminSession" (
+    "id" UUID NOT NULL DEFAULT gen_random_uuid(),
+    "sessionToken" VARCHAR(128) NOT NULL,
+    "adminUserId" UUID NOT NULL,
+    "expiresAt" TIMESTAMPTZ(6) NOT NULL,
+    "createdAt" TIMESTAMPTZ(6) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "AdminSession_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "AdminUser_email_key" ON "AdminUser"("email");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "AdminSession_sessionToken_key" ON "AdminSession"("sessionToken");
+
+-- CreateIndex
+CREATE INDEX "AdminSession_sessionToken_expiresAt_idx" ON "AdminSession"("sessionToken", "expiresAt");
+
+-- CreateIndex
+CREATE INDEX "AdminSession_adminUserId_idx" ON "AdminSession"("adminUserId");
+
+-- AddForeignKey
+ALTER TABLE "AdminSession" ADD CONSTRAINT "AdminSession_adminUserId_fkey" FOREIGN KEY ("adminUserId") REFERENCES "AdminUser"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -125,3 +125,23 @@ model Session {
   @@index([sessionToken, expiresAt])
   @@index([userId])
 }
+
+model AdminUser {
+  id        String         @id @default(dbgenerated("gen_random_uuid()")) @db.Uuid
+  email     String         @unique @db.VarChar(320)
+  name      String?        @db.VarChar(255)
+  createdAt DateTime       @default(now()) @db.Timestamptz(6)
+  sessions  AdminSession[]
+}
+
+model AdminSession {
+  id           String    @id @default(dbgenerated("gen_random_uuid()")) @db.Uuid
+  sessionToken String    @unique @db.VarChar(128)
+  adminUserId  String    @db.Uuid
+  expiresAt    DateTime  @db.Timestamptz(6)
+  createdAt    DateTime  @default(now()) @db.Timestamptz(6)
+  adminUser    AdminUser @relation(fields: [adminUserId], references: [id], onDelete: Cascade)
+
+  @@index([sessionToken, expiresAt])
+  @@index([adminUserId])
+}

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -129,6 +129,8 @@ model Session {
 model AdminUser {
   id        String         @id @default(dbgenerated("gen_random_uuid()")) @db.Uuid
   email     String         @unique @db.VarChar(320)
+  // name is intentionally optional: admins are provisioned by email only
+  // (via seed script) and a display name can be set later if needed.
   name      String?        @db.VarChar(255)
   createdAt DateTime       @default(now()) @db.Timestamptz(6)
   sessions  AdminSession[]

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -256,7 +256,23 @@ export const tasks: SeedTask[] = [
   },
 ];
 
+async function seedAdminUser() {
+  const email = process.env.ADMIN_SEED_EMAIL;
+  if (!email) {
+    console.warn("ADMIN_SEED_EMAIL not set — skipping admin user seed");
+    return;
+  }
+  await prisma.adminUser.upsert({
+    where: { email },
+    create: { email },
+    update: {},
+  });
+  console.log(`Admin user seeded: ${email}`);
+}
+
 async function main() {
+  await seedAdminUser();
+
   for (const t of tasks) {
     await prisma.task.upsert({
       where: { slug: t.slug },

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -268,6 +268,10 @@ async function seedAdminUser() {
     console.warn("ADMIN_SEED_EMAIL is not a valid email address — skipping admin user seed");
     return;
   }
+  if (email.length > 320) {
+    console.warn("ADMIN_SEED_EMAIL exceeds 320 characters — skipping admin user seed");
+    return;
+  }
   await prisma.adminUser.upsert({
     where: { email },
     create: { email },

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -1,6 +1,6 @@
 // prisma/seed.ts
 import { PrismaClient, TaskCategory, EmploymentStatus, Prisma } from "../src/generated/prisma/client";
-import { EMAIL_REGEX } from "../src/lib/utils";
+import { EMAIL_REGEX } from "../src/lib/validation";
 import { PrismaPg } from "@prisma/adapter-pg";
 import path from "path";
 import { fileURLToPath } from "url";

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -257,17 +257,19 @@ export const tasks: SeedTask[] = [
 ];
 
 async function seedAdminUser() {
-  const email = process.env.ADMIN_SEED_EMAIL;
-  if (!email) {
+  const raw = process.env.ADMIN_SEED_EMAIL;
+  if (!raw) {
     console.warn("ADMIN_SEED_EMAIL not set — skipping admin user seed");
     return;
   }
+  const email = raw.trim().toLowerCase();
   await prisma.adminUser.upsert({
     where: { email },
     create: { email },
     update: {},
   });
-  console.log(`Admin user seeded: ${email}`);
+  const masked = email.replace(/^(.{2}).+(@.+)$/, "$1***$2");
+  console.log(`Admin user seeded: ${masked}`);
 }
 
 async function main() {

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -1,5 +1,6 @@
 // prisma/seed.ts
 import { PrismaClient, TaskCategory, EmploymentStatus, Prisma } from "../src/generated/prisma/client";
+import { EMAIL_REGEX } from "../src/lib/utils";
 import { PrismaPg } from "@prisma/adapter-pg";
 import path from "path";
 import { fileURLToPath } from "url";
@@ -263,13 +264,16 @@ async function seedAdminUser() {
     return;
   }
   const email = raw.trim().toLowerCase();
+  if (!email || !EMAIL_REGEX.test(email)) {
+    console.warn("ADMIN_SEED_EMAIL is not a valid email address — skipping admin user seed");
+    return;
+  }
   await prisma.adminUser.upsert({
     where: { email },
     create: { email },
     update: {},
   });
-  const masked = email.replace(/^(.{2}).+(@.+)$/, "$1***$2");
-  console.log(`Admin user seeded: ${masked}`);
+  console.log("Admin user seeded successfully");
 }
 
 async function main() {

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -5,11 +5,7 @@ export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs));
 }
 
-/**
- * RFC 5321 compliant email regex.
- */
-export const EMAIL_REGEX =
-  /^[a-zA-Z0-9.!#$%&'*+/=?^_`{|}~-]+@[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?(?:\.[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)*$/;
+export { EMAIL_REGEX } from "./validation";
 
 /**
  * Converts a SNAKE_CASE enum key to Title Case for display.

--- a/src/lib/validation.ts
+++ b/src/lib/validation.ts
@@ -1,0 +1,8 @@
+/**
+ * RFC 5321 compliant email regex.
+ * Kept in a server-safe module with no UI dependencies so it can be
+ * imported from seed scripts and server-only code without pulling in
+ * frontend helpers (clsx, tailwind-merge, etc.).
+ */
+export const EMAIL_REGEX =
+  /^[a-zA-Z0-9.!#$%&'*+/=?^_`{|}~-]+@[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?(?:\.[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)*$/;

--- a/src/lib/validation.ts
+++ b/src/lib/validation.ts
@@ -1,5 +1,8 @@
 /**
- * RFC 5321 compliant email regex.
+ * Basic email format regex used by the app.
+ * It intentionally validates a practical subset of common email addresses,
+ * not every RFC-allowed form (for example, quoted local parts and address
+ * literals are not supported).
  * Kept in a server-safe module with no UI dependencies so it can be
  * imported from seed scripts and server-only code without pulling in
  * frontend helpers (clsx, tailwind-merge, etc.).


### PR DESCRIPTION
Closes #226. Part of #129.

## Summary
- Adds `AdminUser` model — stores admin accounts, provisioned only via seed script, never through the API
- Adds `AdminSession` model — 4-hour sessions with cascade delete on `AdminUser`, indexed on `(sessionToken, expiresAt)` and `(adminUserId)`
- Updates `.env.example` with three new vars: `ADMIN_PATH`, `ADMIN_SESSION_COOKIE_SECRET`, `ADMIN_SEED_EMAIL`
- Updates `prisma/seed.ts` to upsert an initial `AdminUser` from `ADMIN_SEED_EMAIL` (idempotent, skips gracefully if env var is unset)

## No changes to existing models
`User`, `Session`, `OTPCode`, and all other models are untouched. `OTPCode` is reused as-is for admin OTP flows (it is email-keyed with no FK).

## Test plan
- [ ] `npm run build` passes (Prisma client generated, TypeScript compiles, Next.js builds)
- [ ] `npm run test:unit` — all 327 tests pass, no regressions
- [ ] `npm run lint` — 0 errors
- [ ] Migration applies cleanly on a fresh DB (`prisma migrate reset`)
- [ ] Re-running seed is idempotent (no duplicate-key error on second run)
- [ ] `ADMIN_SEED_EMAIL` unset → seed logs a warning and skips without failing

Made with [Cursor](https://cursor.com)