### PR TITLE
feat: admin portal — Phase 2: auth (login page + OTP flow + session management)

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -38,6 +38,8 @@ Repository Layer  ← only layer that imports from Prisma
 | `prisma/seed.ts` | Seed script runs outside the app |
 | `e2e/helpers/db-setup.ts` | E2E test database setup |
 | `e2e/helpers/db-teardown.ts` | E2E test database teardown |
+| `e2e/helpers/admin-db-setup.ts` | Admin portal E2E test database setup |
+| `e2e/helpers/admin-db-teardown.ts` | Admin portal E2E test database teardown |
 
 No other file should import from `@prisma/client` or `src/generated/prisma/`.
 

--- a/e2e/admin-portal.spec.ts
+++ b/e2e/admin-portal.spec.ts
@@ -1,0 +1,232 @@
+import { test, expect } from "@playwright/test";
+import {
+  ADMIN_AUTH_STATE_PATH,
+  ADMIN_LOGOUT_AUTH_STATE_PATH,
+} from "./global-setup";
+
+/**
+ * The public admin URL prefix — driven by the ADMIN_PATH env var baked into
+ * the Next.js production server at startup.  Falls back to the same default
+ * used in playwright.config.ts so the tests are self-consistent when run
+ * without an explicit env var.
+ */
+const ADMIN_PATH = process.env.ADMIN_PATH || "e2e-admin-portal";
+const ADMIN_LOGIN_URL = `/${ADMIN_PATH}/login`;
+const ADMIN_DASHBOARD_URL = `/${ADMIN_PATH}/dashboard`;
+
+const EXPRESS_API_BASE = "http://localhost:3001/api";
+
+/** Retrieves the latest valid OTP from the test-peek endpoint. */
+async function peekOtp(email: string): Promise<number> {
+  const response = await fetch(
+    `${EXPRESS_API_BASE}/otp/test-peek?email=${encodeURIComponent(email)}`,
+  );
+  if (!response.ok) {
+    throw new Error(`test-peek failed: ${response.status} ${await response.text()}`);
+  }
+  const data = (await response.json()) as { code: number };
+  return data.code;
+}
+
+/** Unauthenticated browser context (no cookies at all). */
+const unauthenticatedTest = test.extend({
+  storageState: { cookies: [], origins: [] },
+});
+
+/** Authenticated as the E2E admin user. */
+const adminTest = test.extend({
+  storageState: ADMIN_AUTH_STATE_PATH,
+});
+
+/** Isolated admin session used only by the logout test. */
+const adminLogoutTest = test.extend({
+  storageState: ADMIN_LOGOUT_AUTH_STATE_PATH,
+});
+
+// ── Security: direct /portal access is always blocked ──────────────────────
+
+test.describe("Direct /portal access is blocked", () => {
+  unauthenticatedTest(
+    "should redirect /portal to home when accessed directly",
+    async ({ page }) => {
+      await page.goto("/portal");
+      await expect(page).toHaveURL("/");
+    },
+  );
+
+  unauthenticatedTest(
+    "should redirect /portal/login to home when accessed directly",
+    async ({ page }) => {
+      await page.goto("/portal/login");
+      await expect(page).toHaveURL("/");
+    },
+  );
+
+  unauthenticatedTest(
+    "should redirect /portal/dashboard to home when accessed directly",
+    async ({ page }) => {
+      await page.goto("/portal/dashboard");
+      await expect(page).toHaveURL("/");
+    },
+  );
+});
+
+// ── Unauthenticated routing ─────────────────────────────────────────────────
+
+test.describe("Admin portal unauthenticated routing", () => {
+  unauthenticatedTest(
+    "should show the admin login page at the configured ADMIN_PATH",
+    async ({ page }) => {
+      await page.goto(ADMIN_LOGIN_URL);
+      await expect(page).toHaveURL(ADMIN_LOGIN_URL);
+      await expect(page.getByRole("heading", { name: "Admin Portal" })).toBeVisible();
+    },
+  );
+
+  unauthenticatedTest(
+    "should redirect unauthenticated users from admin dashboard to admin login",
+    async ({ page }) => {
+      await page.goto(ADMIN_DASHBOARD_URL);
+      await expect(page).toHaveURL(new RegExp(ADMIN_LOGIN_URL));
+    },
+  );
+});
+
+// ── Admin login flow ────────────────────────────────────────────────────────
+
+const OTP_LOGIN_EMAIL = "e2e-admin-otp-login@example.com";
+
+test.describe("Admin login OTP flow", () => {
+  unauthenticatedTest("should show email step on login page", async ({ page }) => {
+    await page.goto(ADMIN_LOGIN_URL);
+    await expect(page.getByLabel("Email Address")).toBeVisible();
+    await expect(page.getByRole("button", { name: "Send Code" })).toBeVisible();
+  });
+
+  unauthenticatedTest(
+    "should show an error for an empty email on submit",
+    async ({ page }) => {
+      await page.goto(ADMIN_LOGIN_URL);
+      await page.getByRole("button", { name: "Send Code" }).click();
+      await expect(page.locator('[role="alert"].text-destructive')).toContainText(
+        /email is required/i,
+      );
+    },
+  );
+
+  unauthenticatedTest(
+    "should show an error for an invalid email format",
+    async ({ page }) => {
+      await page.goto(ADMIN_LOGIN_URL);
+      await page.getByLabel("Email Address").fill("not-an-email");
+      await page.getByRole("button", { name: "Send Code" }).click();
+      await expect(page.locator('[role="alert"].text-destructive')).toContainText(
+        /invalid email format/i,
+      );
+    },
+  );
+
+  unauthenticatedTest(
+    "should advance to OTP step after submitting a valid email",
+    async ({ page }) => {
+      await page.goto(ADMIN_LOGIN_URL);
+      await page.getByLabel("Email Address").fill(OTP_LOGIN_EMAIL);
+      await page.getByRole("button", { name: "Send Code" }).click();
+
+      // Generic message is shown regardless of whether the email is an admin
+      await expect(page.getByLabel("Verification Code")).toBeVisible({ timeout: 10_000 });
+      await expect(page.getByRole("button", { name: "Verify & Login" })).toBeVisible();
+    },
+  );
+
+  unauthenticatedTest(
+    "should show an error for a wrong OTP code",
+    async ({ page }) => {
+      await page.goto(ADMIN_LOGIN_URL);
+      await page.getByLabel("Email Address").fill(OTP_LOGIN_EMAIL);
+      await page.getByRole("button", { name: "Send Code" }).click();
+      await expect(page.getByLabel("Verification Code")).toBeVisible({ timeout: 10_000 });
+
+      await page.getByLabel("Verification Code").fill("100001");
+      await page.getByRole("button", { name: "Verify & Login" }).click();
+      // Either "Invalid or expired OTP" or "Unauthorized" from the admin verify endpoint
+      await expect(page.locator('[role="alert"].text-destructive')).toBeVisible({
+        timeout: 10_000,
+      });
+    },
+  );
+
+  unauthenticatedTest(
+    "should allow going back to email step via Change Email",
+    async ({ page }) => {
+      await page.goto(ADMIN_LOGIN_URL);
+      await page.getByLabel("Email Address").fill(OTP_LOGIN_EMAIL);
+      await page.getByRole("button", { name: "Send Code" }).click();
+      await expect(page.getByLabel("Verification Code")).toBeVisible({ timeout: 10_000 });
+
+      await page.getByRole("button", { name: "Change Email" }).click();
+      await expect(page.getByLabel("Email Address")).toBeVisible();
+    },
+  );
+
+  unauthenticatedTest(
+    "should log in successfully with the correct OTP and redirect to admin dashboard",
+    async ({ page }) => {
+      // Use the pre-seeded admin email — only admin emails generate a real OTP
+      const ADMIN_EMAIL = "e2e-admin@example.com";
+
+      await page.goto(ADMIN_LOGIN_URL);
+      await page.getByLabel("Email Address").fill(ADMIN_EMAIL);
+      await page.getByRole("button", { name: "Send Code" }).click();
+      await expect(page.getByLabel("Verification Code")).toBeVisible({ timeout: 10_000 });
+
+      const code = await peekOtp(ADMIN_EMAIL);
+      await page.getByLabel("Verification Code").fill(String(code));
+      await page.getByRole("button", { name: "Verify & Login" }).click();
+
+      await expect(page).toHaveURL(new RegExp(ADMIN_DASHBOARD_URL), { timeout: 15_000 });
+    },
+  );
+});
+
+// ── Authenticated admin routing ─────────────────────────────────────────────
+
+test.describe("Authenticated admin routing", () => {
+  adminTest(
+    "should allow an authenticated admin to access the dashboard",
+    async ({ page }) => {
+      await page.goto(ADMIN_DASHBOARD_URL);
+      await expect(page).toHaveURL(ADMIN_DASHBOARD_URL);
+      await expect(page.getByRole("heading", { name: "Admin Portal" })).toBeVisible();
+    },
+  );
+
+  adminTest(
+    "should redirect an authenticated admin away from login to dashboard",
+    async ({ page }) => {
+      await page.goto(ADMIN_LOGIN_URL);
+      await expect(page).toHaveURL(new RegExp(ADMIN_DASHBOARD_URL));
+    },
+  );
+});
+
+// ── Admin logout ────────────────────────────────────────────────────────────
+
+test.describe("Admin logout", () => {
+  adminLogoutTest(
+    "should log out and lose access to the admin dashboard",
+    async ({ page }) => {
+      // Verify we can access the dashboard first
+      await page.goto(ADMIN_DASHBOARD_URL);
+      await expect(page).toHaveURL(ADMIN_DASHBOARD_URL);
+
+      // Call the logout API directly
+      const logoutResponse = await page.request.post("/api/admin/auth/logout");
+      expect(logoutResponse.ok()).toBe(true);
+
+      // Navigate to dashboard — should now redirect to login
+      await page.goto(ADMIN_DASHBOARD_URL);
+      await expect(page).toHaveURL(new RegExp(ADMIN_LOGIN_URL));
+    },
+  );
+});

--- a/e2e/admin-portal.spec.ts
+++ b/e2e/admin-portal.spec.ts
@@ -11,6 +11,7 @@ import {
  * without an explicit env var.
  */
 const ADMIN_PATH = process.env.ADMIN_PATH || "e2e-admin-portal";
+const ADMIN_ROOT_URL = `/${ADMIN_PATH}`;
 const ADMIN_LOGIN_URL = `/${ADMIN_PATH}/login`;
 const ADMIN_DASHBOARD_URL = `/${ADMIN_PATH}/dashboard`;
 
@@ -74,6 +75,14 @@ test.describe("Direct /portal access is blocked", () => {
 // ── Unauthenticated routing ─────────────────────────────────────────────────
 
 test.describe("Admin portal unauthenticated routing", () => {
+  unauthenticatedTest(
+    "should redirect the bare admin path to login",
+    async ({ page }) => {
+      await page.goto(ADMIN_ROOT_URL);
+      await expect(page).toHaveURL(ADMIN_LOGIN_URL);
+    },
+  );
+
   unauthenticatedTest(
     "should show the admin login page at the configured ADMIN_PATH",
     async ({ page }) => {
@@ -192,6 +201,14 @@ test.describe("Admin login OTP flow", () => {
 // ── Authenticated admin routing ─────────────────────────────────────────────
 
 test.describe("Authenticated admin routing", () => {
+  adminTest(
+    "should redirect the bare admin path to the dashboard",
+    async ({ page }) => {
+      await page.goto(ADMIN_ROOT_URL);
+      await expect(page).toHaveURL(ADMIN_DASHBOARD_URL);
+    },
+  );
+
   adminTest(
     "should allow an authenticated admin to access the dashboard",
     async ({ page }) => {

--- a/e2e/global-setup.ts
+++ b/e2e/global-setup.ts
@@ -9,11 +9,7 @@ import { config as loadDotenv } from "dotenv";
 loadDotenv({ path: path.join(process.cwd(), ".env") });
 
 // Inline the HMAC signing so this file has no runtime import from src/
-async function signSessionCookie(
-  sessionToken: string,
-  expiresAt: Date,
-  secret: string,
-): Promise<string> {
+async function signCookie(sessionToken: string, expiresAt: Date, secret: string): Promise<string> {
   const enc = new TextEncoder();
   const key = await globalThis.crypto.subtle.importKey(
     "raw",
@@ -35,16 +31,17 @@ async function signSessionCookie(
 }
 
 export const TEST_USER_EMAIL = "e2e-test@example.com";
+export const TEST_ADMIN_EMAIL = "e2e-admin@example.com";
 export const AUTH_STATE_PATH = path.join(__dirname, ".auth", "user.json");
 export const LOGOUT_AUTH_STATE_PATH = path.join(__dirname, ".auth", "user-logout.json");
+export const ADMIN_AUTH_STATE_PATH = path.join(__dirname, ".auth", "admin.json");
+export const ADMIN_LOGOUT_AUTH_STATE_PATH = path.join(__dirname, ".auth", "admin-logout.json");
 
 export default async function globalSetup() {
   // Require a session secret — same var the app uses.
   const secret = process.env.SESSION_COOKIE_SECRET;
   if (!secret) {
-    throw new Error(
-      "SESSION_COOKIE_SECRET env var must be set to run E2E tests",
-    );
+    throw new Error("SESSION_COOKIE_SECRET env var must be set to run E2E tests");
   }
 
   // Run Prisma operations in a tsx subprocess because the Prisma 6
@@ -69,15 +66,15 @@ export default async function globalSetup() {
   const { sessionToken, logoutSessionToken, expiresAt: expiresAtISO } = parsed;
   const expiresAt = new Date(expiresAtISO);
 
-  const sessionSig = await signSessionCookie(sessionToken, expiresAt, secret);
-  const logoutSessionSig = await signSessionCookie(logoutSessionToken, expiresAt, secret);
+  const sessionSig = await signCookie(sessionToken, expiresAt, secret);
+  const logoutSessionSig = await signCookie(logoutSessionToken, expiresAt, secret);
 
   // Persist cookies as Playwright storageState so every test starts authed.
   fs.mkdirSync(path.dirname(AUTH_STATE_PATH), { recursive: true });
 
   const browser = await chromium.launch();
 
-  // Main session: used by all tests.
+  // Main session: used by all regular-user tests.
   const mainContext = await browser.newContext();
   await mainContext.addCookies([
     { name: "session_token", value: sessionToken, domain: "localhost", path: "/", httpOnly: true, secure: false, sameSite: "Lax" },
@@ -85,15 +82,64 @@ export default async function globalSetup() {
   ]);
   await mainContext.storageState({ path: AUTH_STATE_PATH });
 
-  // Logout session: isolated session used only by the logout test so that
-  // when it calls /api/auth/logout (which deletes the session from the DB),
-  // the main session remains intact for all subsequent tests.
+  // Logout session: isolated session used only by the logout test.
   const logoutContext = await browser.newContext();
   await logoutContext.addCookies([
     { name: "session_token", value: logoutSessionToken, domain: "localhost", path: "/", httpOnly: true, secure: false, sameSite: "Lax" },
     { name: "session_sig", value: logoutSessionSig, domain: "localhost", path: "/", httpOnly: true, secure: false, sameSite: "Lax" },
   ]);
   await logoutContext.storageState({ path: LOGOUT_AUTH_STATE_PATH });
+
+  // ── Admin portal sessions (only if ADMIN_PATH + ADMIN_SESSION_COOKIE_SECRET are set) ──
+  const adminPath = process.env.ADMIN_PATH;
+  const adminSecret = process.env.ADMIN_SESSION_COOKIE_SECRET;
+
+  if (adminPath && adminSecret) {
+    const adminHelperScript = path.join(__dirname, "helpers", "admin-db-setup.ts");
+    let adminRaw: string;
+    try {
+      adminRaw = execSync(`npx tsx "${adminHelperScript}" "${TEST_ADMIN_EMAIL}"`, {
+        encoding: "utf-8",
+        env: { ...process.env },
+        stdio: ["pipe", "pipe", "pipe"],
+      }).trim();
+    } catch (err: unknown) {
+      const msg = err instanceof Error ? err.message : String(err);
+      throw new Error(`E2E global-setup: admin-db-setup helper failed: ${msg}`);
+    }
+
+    const adminJsonLine = adminRaw.split("\n").pop()!.trim();
+    const adminParsed = JSON.parse(adminJsonLine);
+    const {
+      sessionToken: adminSessionToken,
+      logoutSessionToken: adminLogoutSessionToken,
+      expiresAt: adminExpiresAtISO,
+    } = adminParsed;
+    const adminExpiresAt = new Date(adminExpiresAtISO);
+
+    const adminSessionSig = await signCookie(adminSessionToken, adminExpiresAt, adminSecret);
+    const adminLogoutSessionSig = await signCookie(
+      adminLogoutSessionToken,
+      adminExpiresAt,
+      adminSecret,
+    );
+
+    // Admin main session
+    const adminContext = await browser.newContext();
+    await adminContext.addCookies([
+      { name: "admin_session_token", value: adminSessionToken, domain: "localhost", path: "/", httpOnly: true, secure: false, sameSite: "Lax" },
+      { name: "admin_session_sig", value: adminSessionSig, domain: "localhost", path: "/", httpOnly: true, secure: false, sameSite: "Lax" },
+    ]);
+    await adminContext.storageState({ path: ADMIN_AUTH_STATE_PATH });
+
+    // Admin logout session
+    const adminLogoutContext = await browser.newContext();
+    await adminLogoutContext.addCookies([
+      { name: "admin_session_token", value: adminLogoutSessionToken, domain: "localhost", path: "/", httpOnly: true, secure: false, sameSite: "Lax" },
+      { name: "admin_session_sig", value: adminLogoutSessionSig, domain: "localhost", path: "/", httpOnly: true, secure: false, sameSite: "Lax" },
+    ]);
+    await adminLogoutContext.storageState({ path: ADMIN_LOGOUT_AUTH_STATE_PATH });
+  }
 
   await browser.close();
 }

--- a/e2e/global-teardown.ts
+++ b/e2e/global-teardown.ts
@@ -1,6 +1,6 @@
 import path from "path";
 import { execSync } from "child_process";
-import { TEST_USER_EMAIL } from "./global-setup";
+import { TEST_USER_EMAIL, TEST_ADMIN_EMAIL } from "./global-setup";
 
 export default async function globalTeardown() {
   // Run Prisma operations in a tsx subprocess (see global-setup.ts).
@@ -14,5 +14,19 @@ export default async function globalTeardown() {
   } catch (err: unknown) {
     const msg = err instanceof Error ? err.message : String(err);
     throw new Error(`E2E global-teardown: db-teardown helper failed: ${msg}`);
+  }
+
+  if (process.env.ADMIN_PATH) {
+    const adminHelperScript = path.join(__dirname, "helpers", "admin-db-teardown.ts");
+    try {
+      execSync(`npx tsx "${adminHelperScript}" "${TEST_ADMIN_EMAIL}"`, {
+        encoding: "utf-8",
+        env: { ...process.env },
+        stdio: ["pipe", "pipe", "pipe"],
+      });
+    } catch (err: unknown) {
+      const msg = err instanceof Error ? err.message : String(err);
+      throw new Error(`E2E global-teardown: admin-db-teardown helper failed: ${msg}`);
+    }
   }
 }

--- a/e2e/helpers/admin-db-setup.ts
+++ b/e2e/helpers/admin-db-setup.ts
@@ -1,0 +1,63 @@
+/**
+ * Helper script that runs via `tsx` (see db-setup.ts for rationale).
+ *
+ * Creates an AdminUser + two AdminSession rows (main + logout) and
+ * prints a single JSON line to stdout:
+ *   { sessionToken, logoutSessionToken, expiresAt }
+ *
+ * Expects:
+ *   env  DATABASE_URL
+ *   argv[2]  admin email
+ */
+import crypto from "crypto";
+import { PrismaClient } from "../../src/generated/prisma/client";
+import { PrismaPg } from "@prisma/adapter-pg";
+
+async function main() {
+  const email = process.argv[2];
+  if (!email) {
+    console.error("Usage: tsx admin-db-setup.ts <email>");
+    process.exit(1);
+  }
+
+  const connectionString = process.env.DATABASE_URL;
+  if (!connectionString) {
+    console.error("DATABASE_URL environment variable is not set");
+    process.exit(1);
+  }
+  const adapter = new PrismaPg({ connectionString });
+  const prisma = new PrismaClient({ adapter });
+
+  try {
+    const adminUser = await prisma.adminUser.upsert({
+      where: { email },
+      update: {},
+      create: { email, name: "E2E Admin" },
+    });
+
+    const expiresAt = new Date(Date.now() + 24 * 60 * 60 * 1000);
+
+    // Main session: used by all authenticated admin tests.
+    const sessionToken = crypto.randomBytes(48).toString("hex");
+    await prisma.adminSession.create({
+      data: { sessionToken, adminUserId: adminUser.id, expiresAt },
+    });
+
+    // Logout session: used exclusively by the logout test.
+    const logoutSessionToken = crypto.randomBytes(48).toString("hex");
+    await prisma.adminSession.create({
+      data: { sessionToken: logoutSessionToken, adminUserId: adminUser.id, expiresAt },
+    });
+
+    console.log(
+      JSON.stringify({ sessionToken, logoutSessionToken, expiresAt: expiresAt.toISOString() }),
+    );
+  } finally {
+    await prisma.$disconnect();
+  }
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/e2e/helpers/admin-db-teardown.ts
+++ b/e2e/helpers/admin-db-teardown.ts
@@ -1,0 +1,44 @@
+/**
+ * Helper script that runs via `tsx` (see db-setup.ts for rationale).
+ *
+ * Deletes the AdminUser (cascades to AdminSession) and any OTP codes
+ * created by the admin login e2e tests.
+ *
+ * Expects:
+ *   env  DATABASE_URL
+ *   argv[2]  admin email
+ */
+import { PrismaClient } from "../../src/generated/prisma/client";
+import { PrismaPg } from "@prisma/adapter-pg";
+
+async function main() {
+  const email = process.argv[2];
+  if (!email) {
+    console.error("Usage: tsx admin-db-teardown.ts <email>");
+    process.exit(1);
+  }
+
+  const connectionString = process.env.DATABASE_URL;
+  if (!connectionString) {
+    console.error("DATABASE_URL environment variable is not set");
+    process.exit(1);
+  }
+  const adapter = new PrismaPg({ connectionString });
+  const prisma = new PrismaClient({ adapter });
+
+  try {
+    await prisma.adminUser.deleteMany({ where: { email } });
+
+    // OTPCode rows for the admin login flow tests (no FK to AdminUser).
+    await prisma.oTPCode.deleteMany({
+      where: { email: { startsWith: "e2e-admin-" } },
+    });
+  } finally {
+    await prisma.$disconnect();
+  }
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/middleware.ts
+++ b/middleware.ts
@@ -4,40 +4,94 @@ import {
   verifySessionCookie,
   SESSION_SIG_COOKIE_NAME,
 } from "@/lib/sessionCookieSig";
+import {
+  verifyAdminSessionCookie,
+  ADMIN_SESSION_TOKEN_COOKIE_NAME,
+  ADMIN_SESSION_SIG_COOKIE_NAME,
+} from "@/lib/adminSessionCookieSig";
 
 export async function middleware(request: NextRequest) {
   const { pathname } = request.nextUrl;
+
+  // Allow static files and API routes to pass through
+  if (pathname.startsWith("/api") || pathname.startsWith("/_next")) {
+    return NextResponse.next();
+  }
+
+  // ── Admin portal ────────────────────────────────────────────────────────
+  // Block direct access to the internal /portal path. The public URL is the
+  // value of ADMIN_PATH, rewritten to /portal by next.config.ts rewrites.
+  // Without this guard anyone who knows the /portal path could bypass the
+  // obscurity provided by ADMIN_PATH.
+  if (pathname === "/portal" || pathname.startsWith("/portal/")) {
+    return NextResponse.redirect(new URL("/", request.url));
+  }
+
+  // Protect admin portal pages that were reached via the rewrite.
+  // next.config.ts rewrites /{ADMIN_PATH}/* → /portal/*; at this point in
+  // the middleware the rewritten (internal) pathname is visible.
+  const adminPortalProtected = ["/portal/dashboard"];
+  const adminPortalLoginPath = "/portal/login";
+
+  const isAdminProtectedPath = adminPortalProtected.some(
+    (p) => pathname === p || pathname.startsWith(p + "/"),
+  );
+  const isAdminLoginPath =
+    pathname === adminPortalLoginPath || pathname.startsWith(adminPortalLoginPath + "/");
+
+  if (isAdminProtectedPath || isAdminLoginPath) {
+    const adminSessionToken = request.cookies.get(ADMIN_SESSION_TOKEN_COOKIE_NAME)?.value;
+    const adminSessionSig = request.cookies.get(ADMIN_SESSION_SIG_COOKIE_NAME)?.value;
+
+    let isAdminAuthenticated = false;
+    if (adminSessionToken && adminSessionSig) {
+      const secret = process.env.ADMIN_SESSION_COOKIE_SECRET;
+      if (secret) {
+        isAdminAuthenticated = await verifyAdminSessionCookie(
+          adminSessionToken,
+          adminSessionSig,
+          secret,
+        );
+      }
+    }
+
+    const adminPath = process.env.ADMIN_PATH;
+    const adminLoginPublicUrl = adminPath ? `/${adminPath}/login` : adminPortalLoginPath;
+    const adminDashboardPublicUrl = adminPath ? `/${adminPath}/dashboard` : "/portal/dashboard";
+
+    if (isAdminProtectedPath && !isAdminAuthenticated) {
+      return NextResponse.redirect(new URL(adminLoginPublicUrl, request.url));
+    }
+
+    if (isAdminLoginPath && isAdminAuthenticated) {
+      return NextResponse.redirect(new URL(adminDashboardPublicUrl, request.url));
+    }
+
+    return NextResponse.next();
+  }
+
+  // ── Regular user routes ─────────────────────────────────────────────────
 
   // Routes that authenticated users should not access
   const authOnlyPaths = ["/login"];
 
   // Protected routes that require authentication
-  // Exact match or any sub-path (e.g. /profile protects /profile/edit but not /profiles)
   const protectedPaths = ["/dashboard", "/profile"];
 
-  // Allow static files and API routes to pass through
-  if (
-    pathname.startsWith("/api") ||
-    pathname.startsWith("/_next")
-  ) {
-    return NextResponse.next();
-  }
+  const isProtectedPath = protectedPaths.some(
+    (path) => pathname === path || pathname.startsWith(path + "/"),
+  );
+  const isAuthPath = authOnlyPaths.some(
+    (path) => pathname === path || pathname.startsWith(path + "/"),
+  );
 
-  // Check if current path is protected or auth-only
-  // Use exact match or prefix with "/" to avoid false positives (e.g. /tasks-review matching /tasks)
-  const isProtectedPath = protectedPaths.some((path) => pathname === path || pathname.startsWith(path + "/"));
-  const isAuthPath = authOnlyPaths.some((path) => pathname === path || pathname.startsWith(path + "/"));
-
-  // Skip authentication check if path is neither protected nor auth-only
   if (!isProtectedPath && !isAuthPath) {
     return NextResponse.next();
   }
 
-  // Only verify session for paths that need authentication checks
   const sessionToken = request.cookies.get("session_token")?.value;
   const sessionSig = request.cookies.get(SESSION_SIG_COOKIE_NAME)?.value;
 
-  // Check if session is valid
   let isAuthenticated = false;
   if (sessionToken && sessionSig) {
     const secret = process.env.SESSION_COOKIE_SECRET;
@@ -46,21 +100,17 @@ export async function middleware(request: NextRequest) {
     }
   }
 
-  // Redirect unauthenticated users from protected routes to login
   if (isProtectedPath && !isAuthenticated) {
     const loginUrl = new URL("/login", request.url);
-    // Include both pathname and search params in redirect
     const redirectPath = pathname + request.nextUrl.search;
     loginUrl.searchParams.set("redirect", redirectPath);
     return NextResponse.redirect(loginUrl);
   }
 
-  // Redirect authenticated users away from login to dashboard
   if (isAuthPath && isAuthenticated) {
     return NextResponse.redirect(new URL("/dashboard", request.url));
   }
 
-  // Allow public paths and authenticated access to protected paths
   return NextResponse.next();
 }
 
@@ -73,6 +123,6 @@ export const config = {
      * - _next/image (image optimization files)
      * - favicon.ico (favicon file)
      */
-    '/((?!api|_next/static|_next/image|favicon.ico).*)',
+    "/((?!api|_next/static|_next/image|favicon.ico).*)",
   ],
 };

--- a/middleware.ts
+++ b/middleware.ts
@@ -53,6 +53,11 @@ export async function middleware(request: NextRequest) {
       }
     }
 
+    if (rest === "/") {
+      const destination = isAdminAuthenticated ? "dashboard" : "login";
+      return NextResponse.redirect(new URL(`/${adminPath}/${destination}`, request.url));
+    }
+
     if (isAdminProtectedPath && !isAdminAuthenticated) {
       return NextResponse.redirect(new URL(`/${adminPath}/login`, request.url));
     }

--- a/middleware.ts
+++ b/middleware.ts
@@ -19,27 +19,25 @@ export async function middleware(request: NextRequest) {
   }
 
   // ── Admin portal ────────────────────────────────────────────────────────
-  // Block direct access to the internal /portal path. The public URL is the
-  // value of ADMIN_PATH, rewritten to /portal by next.config.ts rewrites.
-  // Without this guard anyone who knows the /portal path could bypass the
-  // obscurity provided by ADMIN_PATH.
+  // Block direct access to the internal /portal path so the public URL
+  // (configured via ADMIN_PATH) is the only entry point.
   if (pathname === "/portal" || pathname.startsWith("/portal/")) {
     return NextResponse.redirect(new URL("/", request.url));
   }
 
-  // Protect admin portal pages that were reached via the rewrite.
-  // next.config.ts rewrites /{ADMIN_PATH}/* → /portal/*; at this point in
-  // the middleware the rewritten (internal) pathname is visible.
-  const adminPortalProtected = ["/portal/dashboard"];
-  const adminPortalLoginPath = "/portal/login";
+  const adminPath = process.env.ADMIN_PATH;
+  if (adminPath && (pathname === `/${adminPath}` || pathname.startsWith(`/${adminPath}/`))) {
+    // Map the public /{ADMIN_PATH}/* URL to the internal /portal/* path for
+    // auth checking, then rewrite. Auth is checked here (before the rewrite)
+    // so unauthenticated requests are redirected without serving page content.
+    const rest = pathname.slice(`/${adminPath}`.length) || "/";
+    const internalPath = `/portal${rest === "/" ? "" : rest}`;
 
-  const isAdminProtectedPath = adminPortalProtected.some(
-    (p) => pathname === p || pathname.startsWith(p + "/"),
-  );
-  const isAdminLoginPath =
-    pathname === adminPortalLoginPath || pathname.startsWith(adminPortalLoginPath + "/");
+    const isAdminProtectedPath =
+      internalPath === "/portal/dashboard" || internalPath.startsWith("/portal/dashboard/");
+    const isAdminLoginPath =
+      internalPath === "/portal/login" || internalPath.startsWith("/portal/login/");
 
-  if (isAdminProtectedPath || isAdminLoginPath) {
     const adminSessionToken = request.cookies.get(ADMIN_SESSION_TOKEN_COOKIE_NAME)?.value;
     const adminSessionSig = request.cookies.get(ADMIN_SESSION_SIG_COOKIE_NAME)?.value;
 
@@ -55,19 +53,15 @@ export async function middleware(request: NextRequest) {
       }
     }
 
-    const adminPath = process.env.ADMIN_PATH;
-    const adminLoginPublicUrl = adminPath ? `/${adminPath}/login` : adminPortalLoginPath;
-    const adminDashboardPublicUrl = adminPath ? `/${adminPath}/dashboard` : "/portal/dashboard";
-
     if (isAdminProtectedPath && !isAdminAuthenticated) {
-      return NextResponse.redirect(new URL(adminLoginPublicUrl, request.url));
+      return NextResponse.redirect(new URL(`/${adminPath}/login`, request.url));
     }
-
     if (isAdminLoginPath && isAdminAuthenticated) {
-      return NextResponse.redirect(new URL(adminDashboardPublicUrl, request.url));
+      return NextResponse.redirect(new URL(`/${adminPath}/dashboard`, request.url));
     }
 
-    return NextResponse.next();
+    // Auth check passed — rewrite to the internal /portal path.
+    return NextResponse.rewrite(new URL(internalPath || "/portal", request.url));
   }
 
   // ── Regular user routes ─────────────────────────────────────────────────

--- a/next.config.ts
+++ b/next.config.ts
@@ -1,10 +1,27 @@
 import type { NextConfig } from "next";
 
+const adminPath = process.env.ADMIN_PATH;
+
 const nextConfig: NextConfig = {
   output: 'standalone',
   serverExternalPackages: ['pino', 'pino-pretty'],
   turbopack: {
     root: __dirname,
+  },
+  // Rewrite the configured admin path to the internal /portal route so that
+  // the public URL is the obscure value from ADMIN_PATH rather than /portal.
+  async rewrites() {
+    if (!adminPath) return [];
+    return [
+      {
+        source: `/${adminPath}`,
+        destination: "/portal",
+      },
+      {
+        source: `/${adminPath}/:path*`,
+        destination: "/portal/:path*",
+      },
+    ];
   },
 };
 

--- a/next.config.ts
+++ b/next.config.ts
@@ -1,27 +1,10 @@
 import type { NextConfig } from "next";
 
-const adminPath = process.env.ADMIN_PATH;
-
 const nextConfig: NextConfig = {
   output: 'standalone',
   serverExternalPackages: ['pino', 'pino-pretty'],
   turbopack: {
     root: __dirname,
-  },
-  // Rewrite the configured admin path to the internal /portal route so that
-  // the public URL is the obscure value from ADMIN_PATH rather than /portal.
-  async rewrites() {
-    if (!adminPath) return [];
-    return [
-      {
-        source: `/${adminPath}`,
-        destination: "/portal",
-      },
-      {
-        source: `/${adminPath}/:path*`,
-        destination: "/portal/:path*",
-      },
-    ];
   },
 };
 

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -66,6 +66,8 @@ export default defineConfig({
         BREVO_API_KEY: '',
         // Must be 'test' so the /otp/test-peek endpoint is registered by Express.
         NODE_ENV: 'test',
+        // Admin portal secrets (optional — admin e2e tests are skipped when unset)
+        ADMIN_SESSION_COOKIE_SECRET: process.env.ADMIN_SESSION_COOKIE_SECRET || 'test-admin-secret-for-e2e-tests-must-be-at-least-32-chars-1234',
       },
     },
     {
@@ -87,6 +89,11 @@ export default defineConfig({
         BREVO_API_KEY: '',
         NODE_ENV: 'test',
         PORT: '3999',
+        // Admin portal: obscure path + secret for E2E.
+        // Set ADMIN_PATH in your .env to enable admin e2e tests locally.
+        // In CI, set ADMIN_PATH and ADMIN_SESSION_COOKIE_SECRET as secrets.
+        ADMIN_PATH: process.env.ADMIN_PATH || 'e2e-admin-portal',
+        ADMIN_SESSION_COOKIE_SECRET: process.env.ADMIN_SESSION_COOKIE_SECRET || 'test-admin-secret-for-e2e-tests-must-be-at-least-32-chars-1234',
       },
     },
   ],

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -4,6 +4,16 @@ import { config as loadDotenv } from 'dotenv';
 
 loadDotenv({ path: path.join(__dirname, '.env') });
 
+// Ensure admin portal env vars are available to global-setup (which runs in
+// the same process as this config) as well as to the webservers.
+if (!process.env.ADMIN_PATH) {
+  process.env.ADMIN_PATH = 'e2e-admin-portal';
+}
+if (!process.env.ADMIN_SESSION_COOKIE_SECRET) {
+  process.env.ADMIN_SESSION_COOKIE_SECRET =
+    'test-admin-secret-for-e2e-tests-must-be-at-least-32-chars-1234';
+}
+
 /**
  * See https://playwright.dev/docs/test-configuration.
  *
@@ -89,11 +99,8 @@ export default defineConfig({
         BREVO_API_KEY: '',
         NODE_ENV: 'test',
         PORT: '3999',
-        // Admin portal: obscure path + secret for E2E.
-        // Set ADMIN_PATH in your .env to enable admin e2e tests locally.
-        // In CI, set ADMIN_PATH and ADMIN_SESSION_COOKIE_SECRET as secrets.
-        ADMIN_PATH: process.env.ADMIN_PATH || 'e2e-admin-portal',
-        ADMIN_SESSION_COOKIE_SECRET: process.env.ADMIN_SESSION_COOKIE_SECRET || 'test-admin-secret-for-e2e-tests-must-be-at-least-32-chars-1234',
+        ADMIN_PATH: process.env.ADMIN_PATH!,
+        ADMIN_SESSION_COOKIE_SECRET: process.env.ADMIN_SESSION_COOKIE_SECRET!,
       },
     },
   ],

--- a/prisma/migrations/20260813124500_add_otp_purpose/migration.sql
+++ b/prisma/migrations/20260813124500_add_otp_purpose/migration.sql
@@ -1,0 +1,11 @@
+-- CreateEnum
+CREATE TYPE "OtpPurpose" AS ENUM ('USER', 'ADMIN');
+
+-- AlterTable
+ALTER TABLE "OTPCode" ADD COLUMN "purpose" "OtpPurpose" NOT NULL DEFAULT 'USER';
+
+-- DropIndex
+DROP INDEX "OTPCode_email_createdAt_idx";
+
+-- CreateIndex
+CREATE INDEX "OTPCode_email_purpose_createdAt_idx" ON "OTPCode"("email", "purpose", "createdAt");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -45,42 +45,47 @@ enum UserTaskStatus {
   DONE
 }
 
+enum OtpPurpose {
+  USER
+  ADMIN
+}
+
 model User {
-  id                  String            @id @default(uuid()) @db.Uuid
-  email               String            @unique @db.VarChar(320)
-  name                String            @db.VarChar(255)
-  isEU                Boolean?
-  employmentStatus    EmploymentStatus?
-  hasChildren         Boolean?
-  housingType         HousingType?
-  plannedArrivalDate  DateTime?         @db.Date
-  arrivalDate         DateTime?         @db.Date
-  createdAt           DateTime          @default(now()) @db.Timestamptz(6)
-  updatedAt           DateTime          @updatedAt @db.Timestamptz(6)
-  userTasks           UserTask[]
-  sessions            Session[]
-  createdTasks        Task[]
+  id                 String            @id @default(uuid()) @db.Uuid
+  email              String            @unique @db.VarChar(320)
+  name               String            @db.VarChar(255)
+  isEU               Boolean?
+  employmentStatus   EmploymentStatus?
+  hasChildren        Boolean?
+  housingType        HousingType?
+  plannedArrivalDate DateTime?         @db.Date
+  arrivalDate        DateTime?         @db.Date
+  createdAt          DateTime          @default(now()) @db.Timestamptz(6)
+  updatedAt          DateTime          @updatedAt @db.Timestamptz(6)
+  userTasks          UserTask[]
+  sessions           Session[]
+  createdTasks       Task[]
 }
 
 model Task {
-  id                         String             @id @default(dbgenerated("gen_random_uuid()")) @db.Uuid
-  slug                       String             @unique @db.VarChar(80)
-  title                      String             @db.VarChar(140)
-  shortDescription           String             @db.VarChar(280)
-  body                       String             @db.Text
-  category                   TaskCategory
-  officialLinks              Json               @db.JsonB
-  requiresEU                 Boolean?
-  requiresEmploymentStatus   EmploymentStatus[]
-  requiresChildren           Boolean?
-  minDaysFromArrival         Int?               @db.SmallInt
-  maxDaysFromArrival         Int?               @db.SmallInt
-  sortOrder                  Int                @db.SmallInt
-  createdByUserId            String?            @db.Uuid
-  createdAt                  DateTime           @default(now()) @db.Timestamptz(6)
-  updatedAt                  DateTime           @updatedAt @db.Timestamptz(6)
-  createdBy                  User?              @relation(fields: [createdByUserId], references: [id], onDelete: Cascade)
-  userTasks                  UserTask[]
+  id                       String             @id @default(dbgenerated("gen_random_uuid()")) @db.Uuid
+  slug                     String             @unique @db.VarChar(80)
+  title                    String             @db.VarChar(140)
+  shortDescription         String             @db.VarChar(280)
+  body                     String             @db.Text
+  category                 TaskCategory
+  officialLinks            Json               @db.JsonB
+  requiresEU               Boolean?
+  requiresEmploymentStatus EmploymentStatus[]
+  requiresChildren         Boolean?
+  minDaysFromArrival       Int?               @db.SmallInt
+  maxDaysFromArrival       Int?               @db.SmallInt
+  sortOrder                Int                @db.SmallInt
+  createdByUserId          String?            @db.Uuid
+  createdAt                DateTime           @default(now()) @db.Timestamptz(6)
+  updatedAt                DateTime           @updatedAt @db.Timestamptz(6)
+  createdBy                User?              @relation(fields: [createdByUserId], references: [id], onDelete: Cascade)
+  userTasks                UserTask[]
 
   @@index([category, sortOrder])
   @@index([slug])
@@ -105,13 +110,14 @@ model UserTask {
 }
 
 model OTPCode {
-  id        String   @id @default(dbgenerated("gen_random_uuid()")) @db.Uuid
-  email     String   @db.VarChar(320)
-  code      Int      @db.Integer
-  expiresAt DateTime @db.Timestamptz(6)
-  createdAt DateTime @default(now()) @db.Timestamptz(6)
+  id        String     @id @default(dbgenerated("gen_random_uuid()")) @db.Uuid
+  email     String     @db.VarChar(320)
+  code      Int        @db.Integer
+  purpose   OtpPurpose @default(USER)
+  expiresAt DateTime   @db.Timestamptz(6)
+  createdAt DateTime   @default(now()) @db.Timestamptz(6)
 
-  @@index([email, createdAt])
+  @@index([email, purpose, createdAt])
 }
 
 model Session {

--- a/src/__tests__/README.md
+++ b/src/__tests__/README.md
@@ -43,6 +43,7 @@ src/__tests__/
 ├── setup.ts                          # Test configuration (dotenv)
 ├── README.md                         # This file
 ├── app-routing.test.ts               # Route auth policy (public vs protected)
+├── adminRoutingMiddleware.test.ts    # Admin and regular Next.js middleware routing
 ├── authMiddleware.test.ts            # Session authentication middleware
 ├── authProfile.test.ts               # Auth profile endpoints (GET/PATCH/DELETE)
 ├── authSession.test.ts               # GET /api/auth/session success-path

--- a/src/__tests__/adminAuth.test.ts
+++ b/src/__tests__/adminAuth.test.ts
@@ -1,0 +1,98 @@
+import { describe, it, expect, vi } from "vitest";
+import request from "supertest";
+import type { Request } from "express";
+import { createApp } from "../app";
+import * as adminRepo from "../repo/adminRepo";
+
+const MOCK_ADMIN_USER = { id: "admin-1", email: "admin@example.com", name: "Admin" };
+const MOCK_ADMIN_SESSION = {
+  id: "admin-session-1",
+  token: "admin-token",
+  expiresAt: new Date("2030-01-01T00:00:00.000Z"),
+};
+
+// Mock tsoa authentication to inject admin user on admin_cookie_auth requests
+vi.mock("../middleware/tsoaAuthentication", () => ({
+  expressAuthentication: vi.fn().mockImplementation((req: Request, securityName: string) => {
+    if (securityName === "admin_cookie_auth") {
+      req.adminUser = MOCK_ADMIN_USER;
+      req.adminSession = MOCK_ADMIN_SESSION;
+      return Promise.resolve(MOCK_ADMIN_USER);
+    }
+    if (securityName === "cookie_auth") {
+      const user = { id: "user-1", email: "user@example.com", name: "User" };
+      req.user = user;
+      req.session = { id: "s-1", token: "tok", expiresAt: new Date("2030-01-01") };
+      return Promise.resolve(user);
+    }
+    return Promise.reject({ status: 401, message: "Unauthorized" });
+  }),
+}));
+
+vi.mock("../repo/adminRepo", () => ({
+  findAdminUserByEmail: vi.fn(),
+  findAdminSessionWithUser: vi.fn(),
+  createAdminSession: vi.fn(),
+  deleteAdminSessionById: vi.fn(),
+  deleteAdminSessionByToken: vi.fn(),
+  deleteAdminUserSessions: vi.fn(),
+}));
+
+const app = createApp();
+
+describe("GET /api/admin/auth/session", () => {
+  it("should return 200 with admin user and session when authenticated", async () => {
+    const response = await request(app).get("/api/admin/auth/session");
+
+    expect(response.status).toBe(200);
+    expect(response.body.authenticated).toBe(true);
+    expect(response.body.adminUser).toEqual(MOCK_ADMIN_USER);
+    expect(response.body.session).toMatchObject({
+      expiresAt: MOCK_ADMIN_SESSION.expiresAt.toISOString(),
+    });
+  });
+
+  it("should return 401 when admin session is missing or invalid", async () => {
+    const { expressAuthentication } = await import("../middleware/tsoaAuthentication");
+    vi.mocked(expressAuthentication).mockRejectedValueOnce({
+      status: 401,
+      message: "Unauthorized",
+    });
+
+    const response = await request(app).get("/api/admin/auth/session");
+
+    expect(response.status).toBe(401);
+  });
+});
+
+describe("POST /api/admin/auth/logout", () => {
+  it("should return 200 and delete the admin session token", async () => {
+    vi.mocked(adminRepo.deleteAdminSessionByToken).mockResolvedValue({ count: 1 });
+
+    const response = await request(app)
+      .post("/api/admin/auth/logout")
+      .set("Cookie", "admin_session_token=admin-token");
+
+    expect(response.status).toBe(200);
+    expect(response.body.success).toBe(true);
+    expect(adminRepo.deleteAdminSessionByToken).toHaveBeenCalledWith("admin-token");
+  });
+
+  it("should return 200 even when no session token cookie is present", async () => {
+    const response = await request(app).post("/api/admin/auth/logout");
+
+    expect(response.status).toBe(200);
+    expect(response.body.success).toBe(true);
+  });
+
+  it("should return 500 when session deletion fails unexpectedly", async () => {
+    vi.mocked(adminRepo.deleteAdminSessionByToken).mockRejectedValue(new Error("DB error"));
+
+    const response = await request(app)
+      .post("/api/admin/auth/logout")
+      .set("Cookie", "admin_session_token=admin-token");
+
+    expect(response.status).toBe(500);
+    expect(response.body.error).toBe("Failed to logout");
+  });
+});

--- a/src/__tests__/adminOtp.test.ts
+++ b/src/__tests__/adminOtp.test.ts
@@ -382,6 +382,7 @@ describe("Admin OTP API", () => {
         "nobody@example.com",
         expect.any(Number),
         expect.any(Date),
+        "ADMIN",
       );
       expect(mockEmailService.sendEmail).not.toHaveBeenCalled();
     });
@@ -513,7 +514,7 @@ describe("Admin OTP API", () => {
       expect(result.sessionToken).toBeDefined();
       expect(result.sessionToken).toHaveLength(128);
       expect(result.adminUser).toMatchObject({ email: "admin@example.com" });
-      expect(otpRepo.deleteAllOtpsByEmail).toHaveBeenCalledWith("admin@example.com", transactionClient);
+      expect(otpRepo.deleteAllOtpsByEmail).toHaveBeenCalledWith("admin@example.com", "ADMIN", transactionClient);
       expect(adminRepo.findAdminUserByEmail).toHaveBeenCalledWith("admin@example.com", transactionClient);
       expect(adminRepo.deleteAdminUserSessions).toHaveBeenCalledWith("admin-1", transactionClient);
       expect(adminRepo.createAdminSession).toHaveBeenCalledWith(
@@ -538,6 +539,7 @@ describe("Admin OTP API", () => {
 
       expect(otpRepo.deleteAllOtpsByEmail).toHaveBeenCalledWith(
         "admin@example.com",
+        "ADMIN",
         expect.anything(),
       );
     });

--- a/src/__tests__/adminOtp.test.ts
+++ b/src/__tests__/adminOtp.test.ts
@@ -199,6 +199,19 @@ describe("Admin OTP API", () => {
       expect(response.headers["retry-after"]).toBe("300");
     });
 
+    it("should use fallback status and error values when the request service omits them", async () => {
+      const mockRequestOtp = vi.spyOn(adminOtpServiceModule.adminOtpService, "requestOtp");
+      mockRequestOtp.mockResolvedValueOnce({ success: false });
+
+      const response = await request(app)
+        .post("/api/admin/otp/generate")
+        .send({ email: "admin@example.com" })
+        .set("Content-Type", "application/json");
+
+      expect(response.status).toBe(500);
+      expect(response.body.error).toBe("An error occurred");
+    });
+
     it("should return generic message even on 429 to prevent enumeration", async () => {
       const mockRequestOtp = vi.spyOn(adminOtpServiceModule.adminOtpService, "requestOtp");
       mockRequestOtp.mockResolvedValueOnce({
@@ -280,6 +293,19 @@ describe("Admin OTP API", () => {
 
       expect(response.status).toBe(401);
       expect(response.body.error).toBe("Invalid or expired OTP");
+    });
+
+    it("should use fallback status and error values when the verification service omits them", async () => {
+      const mockVerifyOtp = vi.spyOn(adminOtpServiceModule.adminOtpService, "verifyOtp");
+      mockVerifyOtp.mockResolvedValueOnce({ success: false });
+
+      const response = await request(app)
+        .post("/api/admin/otp/verify")
+        .send({ email: "admin@example.com", code: 123456 })
+        .set("Content-Type", "application/json");
+
+      expect(response.status).toBe(500);
+      expect(response.body.error).toBe("Verification failed");
     });
 
     it("should return 401 when email belongs to a non-admin user", async () => {
@@ -426,6 +452,17 @@ describe("Admin OTP API", () => {
       expect(result.success).toBe(false);
       expect(result.statusCode).toBe(429);
       expect(result.retryAfter).toBe(300); // 5 minutes remaining
+    });
+
+    it("should use the full rate-limit window when no recent OTP can be found", async () => {
+      vi.mocked(otpRepo.countRecentOtps).mockResolvedValue(3);
+      vi.mocked(otpRepo.findOldestRecentOtp).mockResolvedValue(null);
+
+      const result = await adminOtpService.requestOtp("admin@example.com");
+
+      expect(result.success).toBe(false);
+      expect(result.statusCode).toBe(429);
+      expect(result.retryAfter).toBe(600);
     });
 
     it("should return 500 when email sending fails", async () => {

--- a/src/__tests__/adminOtp.test.ts
+++ b/src/__tests__/adminOtp.test.ts
@@ -1,0 +1,529 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import request from "supertest";
+import express from "express";
+import { RegisterRoutes } from "../generated/routes";
+import { tsoaErrorHandler } from "../middleware/tsoaErrorHandler";
+import { errorLogger } from "../middleware/errorLogger";
+import { requestLogger } from "../middleware/requestLogger";
+import * as adminOtpServiceModule from "../services/adminOtpService";
+import { AdminOtpService } from "../services/adminOtpService";
+import * as otpRepo from "../repo/otpRepo";
+import * as adminRepo from "../repo/adminRepo";
+import type { EmailService } from "../services/email/emailService";
+import type { EmailResult } from "../services/email/types";
+
+// ── Repo mocks ──────────────────────────────────────────────────────────────
+
+vi.mock("../repo/otpRepo", () => ({
+  countRecentOtps: vi.fn(),
+  findOldestRecentOtp: vi.fn(),
+  deleteExpiredOtps: vi.fn(),
+  createOtp: vi.fn(),
+  findValidOtp: vi.fn(),
+  deleteAllOtpsByEmail: vi.fn(),
+}));
+
+vi.mock("../repo/adminRepo", () => ({
+  findAdminUserByEmail: vi.fn(),
+  findAdminSessionWithUser: vi.fn(),
+  createAdminSession: vi.fn(),
+  deleteAdminSessionById: vi.fn(),
+  deleteAdminSessionByToken: vi.fn(),
+  deleteAdminUserSessions: vi.fn(),
+}));
+
+vi.mock("../repo/db", () => ({
+  prisma: {},
+  withTransaction: vi.fn(async (callback: (tx: unknown) => unknown) => callback({})),
+}));
+
+// ── Regular session repo mock (needed by tsoa auth for cookie_auth) ─────────
+vi.mock("../repo/sessionRepo", () => ({
+  findSessionWithUser: vi.fn(),
+  deleteSessionById: vi.fn(),
+  deleteSessionByToken: vi.fn(),
+  deleteUserSessions: vi.fn(),
+  createSession: vi.fn(),
+}));
+
+// ── Helpers ─────────────────────────────────────────────────────────────────
+
+const createTestApp = () => {
+  const app = express();
+  app.use(express.json());
+  app.use(requestLogger);
+  RegisterRoutes(app);
+  app.use(tsoaErrorHandler);
+  app.use(errorLogger);
+  return app;
+};
+
+const MOCK_ADMIN_USER = { id: "admin-1", email: "admin@example.com", name: "Admin" };
+
+const GENERIC_MESSAGE = "If this email is valid, an OTP has been sent.";
+
+// ── POST /api/admin/otp/generate ─────────────────────────────────────────────
+
+describe("Admin OTP API", () => {
+  let app: express.Express;
+  let adminOtpService: AdminOtpService;
+  let mockEmailService: EmailService;
+
+  beforeEach(() => {
+    app = createTestApp();
+
+    mockEmailService = {
+      sendEmail: vi.fn(),
+    } as unknown as EmailService;
+
+    adminOtpService = new AdminOtpService(mockEmailService);
+
+    vi.clearAllMocks();
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2024-01-01T12:00:00Z"));
+
+    // Default admin user mock
+    vi.mocked(adminRepo.findAdminUserByEmail).mockResolvedValue({
+      id: "admin-1",
+      email: "admin@example.com",
+      name: "Admin",
+      createdAt: new Date(),
+    });
+    vi.mocked(adminRepo.deleteAdminUserSessions).mockResolvedValue({ count: 0 });
+    vi.mocked(adminRepo.createAdminSession).mockResolvedValue({
+      id: "admin-session-1",
+      sessionToken: "admin-token",
+      adminUserId: "admin-1",
+      expiresAt: new Date(Date.now() + 7 * 24 * 60 * 60 * 1000),
+      createdAt: new Date(),
+    });
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  describe("POST /api/admin/otp/generate", () => {
+    it("should return 200 with generic message for valid email", async () => {
+      const mockRequestOtp = vi.spyOn(adminOtpServiceModule.adminOtpService, "requestOtp");
+      mockRequestOtp.mockResolvedValueOnce({ success: true });
+
+      const response = await request(app)
+        .post("/api/admin/otp/generate")
+        .send({ email: "admin@example.com" })
+        .set("Content-Type", "application/json");
+
+      expect(response.status).toBe(200);
+      expect(response.body.message).toBe(GENERIC_MESSAGE);
+    });
+
+    it("should normalize email to lowercase before processing", async () => {
+      const mockRequestOtp = vi.spyOn(adminOtpServiceModule.adminOtpService, "requestOtp");
+      mockRequestOtp.mockResolvedValueOnce({ success: true });
+
+      await request(app)
+        .post("/api/admin/otp/generate")
+        .send({ email: "ADMIN@EXAMPLE.COM" })
+        .set("Content-Type", "application/json");
+
+      expect(mockRequestOtp).toHaveBeenCalledWith("admin@example.com", expect.anything());
+    });
+
+    it("should trim whitespace from email before processing", async () => {
+      const mockRequestOtp = vi.spyOn(adminOtpServiceModule.adminOtpService, "requestOtp");
+      mockRequestOtp.mockResolvedValueOnce({ success: true });
+
+      await request(app)
+        .post("/api/admin/otp/generate")
+        .send({ email: "  admin@example.com  " })
+        .set("Content-Type", "application/json");
+
+      expect(mockRequestOtp).toHaveBeenCalledWith("admin@example.com", expect.anything());
+    });
+
+    it("should return 400 for invalid email format", async () => {
+      const response = await request(app)
+        .post("/api/admin/otp/generate")
+        .send({ email: "not-an-email" })
+        .set("Content-Type", "application/json");
+
+      expect(response.status).toBe(400);
+      expect(response.body.error).toBe("Invalid email format");
+    });
+
+    it("should return 422 for missing email field", async () => {
+      const response = await request(app)
+        .post("/api/admin/otp/generate")
+        .send({})
+        .set("Content-Type", "application/json");
+
+      expect(response.status).toBe(422);
+      expect(response.body.message).toBe("Validation Failed");
+    });
+
+    it("should return 422 for email exceeding 320 characters", async () => {
+      const longEmail = "a".repeat(310) + "@example.com";
+
+      const response = await request(app)
+        .post("/api/admin/otp/generate")
+        .send({ email: longEmail })
+        .set("Content-Type", "application/json");
+
+      expect(response.status).toBe(422);
+      expect(response.body.message).toBe("Validation Failed");
+    });
+
+    it("should return 429 when rate limit is exceeded", async () => {
+      const mockRequestOtp = vi.spyOn(adminOtpServiceModule.adminOtpService, "requestOtp");
+      mockRequestOtp.mockResolvedValueOnce({
+        success: false,
+        error: "Rate limit exceeded",
+        statusCode: 429,
+        retryAfter: 300,
+      });
+
+      const response = await request(app)
+        .post("/api/admin/otp/generate")
+        .send({ email: "admin@example.com" })
+        .set("Content-Type", "application/json");
+
+      expect(response.status).toBe(429);
+      expect(response.body.error).toBe("Rate limit exceeded");
+      expect(response.headers["retry-after"]).toBe("300");
+    });
+
+    it("should return generic message even on 429 to prevent enumeration", async () => {
+      const mockRequestOtp = vi.spyOn(adminOtpServiceModule.adminOtpService, "requestOtp");
+      mockRequestOtp.mockResolvedValueOnce({
+        success: false,
+        error: "Rate limit exceeded",
+        statusCode: 429,
+        retryAfter: 60,
+      });
+
+      const response = await request(app)
+        .post("/api/admin/otp/generate")
+        .send({ email: "admin@example.com" })
+        .set("Content-Type", "application/json");
+
+      expect(response.body.message).toBe(GENERIC_MESSAGE);
+    });
+
+    it("should return 200 for non-admin email (no email enumeration)", async () => {
+      // Non-admin email should silently succeed — same response as admin email
+      const mockRequestOtp = vi.spyOn(adminOtpServiceModule.adminOtpService, "requestOtp");
+      mockRequestOtp.mockResolvedValueOnce({ success: true });
+
+      const response = await request(app)
+        .post("/api/admin/otp/generate")
+        .send({ email: "regular@example.com" })
+        .set("Content-Type", "application/json");
+
+      expect(response.status).toBe(200);
+      expect(response.body.message).toBe(GENERIC_MESSAGE);
+    });
+
+    it("should return 500 on unexpected service error", async () => {
+      const mockRequestOtp = vi.spyOn(adminOtpServiceModule.adminOtpService, "requestOtp");
+      mockRequestOtp.mockRejectedValueOnce(new Error("Unexpected error"));
+
+      const response = await request(app)
+        .post("/api/admin/otp/generate")
+        .send({ email: "admin@example.com" })
+        .set("Content-Type", "application/json");
+
+      expect(response.status).toBe(500);
+      expect(response.body.error).toBe("Internal server error");
+    });
+  });
+
+  describe("POST /api/admin/otp/verify", () => {
+    it("should verify valid OTP and return session token + admin user", async () => {
+      const mockVerifyOtp = vi.spyOn(adminOtpServiceModule.adminOtpService, "verifyOtp");
+      mockVerifyOtp.mockResolvedValueOnce({
+        success: true,
+        sessionToken: "admin-session-token",
+        adminUser: MOCK_ADMIN_USER,
+      });
+
+      const response = await request(app)
+        .post("/api/admin/otp/verify")
+        .send({ email: "admin@example.com", code: 123456 })
+        .set("Content-Type", "application/json");
+
+      expect(response.status).toBe(200);
+      expect(response.body.success).toBe(true);
+      expect(response.body.message).toBe("OTP verified successfully");
+      expect(response.body.sessionToken).toBe("admin-session-token");
+      expect(response.body.adminUser).toMatchObject(MOCK_ADMIN_USER);
+    });
+
+    it("should return 401 for invalid or expired OTP", async () => {
+      const mockVerifyOtp = vi.spyOn(adminOtpServiceModule.adminOtpService, "verifyOtp");
+      mockVerifyOtp.mockResolvedValueOnce({
+        success: false,
+        error: "Invalid or expired OTP",
+        statusCode: 401,
+      });
+
+      const response = await request(app)
+        .post("/api/admin/otp/verify")
+        .send({ email: "admin@example.com", code: 999999 })
+        .set("Content-Type", "application/json");
+
+      expect(response.status).toBe(401);
+      expect(response.body.error).toBe("Invalid or expired OTP");
+    });
+
+    it("should return 401 when email belongs to a non-admin user", async () => {
+      const mockVerifyOtp = vi.spyOn(adminOtpServiceModule.adminOtpService, "verifyOtp");
+      mockVerifyOtp.mockResolvedValueOnce({
+        success: false,
+        error: "Unauthorized",
+        statusCode: 401,
+      });
+
+      const response = await request(app)
+        .post("/api/admin/otp/verify")
+        .send({ email: "regular@example.com", code: 123456 })
+        .set("Content-Type", "application/json");
+
+      expect(response.status).toBe(401);
+    });
+
+    it("should return 422 when email field is missing", async () => {
+      const response = await request(app)
+        .post("/api/admin/otp/verify")
+        .send({ code: 123456 })
+        .set("Content-Type", "application/json");
+
+      expect(response.status).toBe(422);
+      expect(response.body.message).toBe("Validation Failed");
+    });
+
+    it("should return 422 when code field is missing", async () => {
+      const response = await request(app)
+        .post("/api/admin/otp/verify")
+        .send({ email: "admin@example.com" })
+        .set("Content-Type", "application/json");
+
+      expect(response.status).toBe(422);
+      expect(response.body.message).toBe("Validation Failed");
+    });
+
+    it("should return 400 for invalid email format on verify", async () => {
+      const response = await request(app)
+        .post("/api/admin/otp/verify")
+        .send({ email: "not-valid", code: 123456 })
+        .set("Content-Type", "application/json");
+
+      expect(response.status).toBe(400);
+      expect(response.body.error).toBe("Invalid email format");
+    });
+
+    it("should normalize email to lowercase before verifying", async () => {
+      const mockVerifyOtp = vi.spyOn(adminOtpServiceModule.adminOtpService, "verifyOtp");
+      mockVerifyOtp.mockResolvedValueOnce({ success: true });
+
+      await request(app)
+        .post("/api/admin/otp/verify")
+        .send({ email: "ADMIN@EXAMPLE.COM", code: 123456 })
+        .set("Content-Type", "application/json");
+
+      expect(mockVerifyOtp).toHaveBeenCalledWith("admin@example.com", 123456, expect.anything());
+    });
+  });
+
+  // ── AdminOtpService unit tests ─────────────────────────────────────────────
+
+  describe("AdminOtpService.requestOtp", () => {
+    it("should silently succeed for non-admin email without sending OTP", async () => {
+      vi.mocked(adminRepo.findAdminUserByEmail).mockResolvedValue(null);
+      vi.mocked(otpRepo.countRecentOtps).mockResolvedValue(0);
+      vi.mocked(otpRepo.deleteExpiredOtps).mockResolvedValue({ count: 0 });
+
+      const result = await adminOtpService.requestOtp("nobody@example.com");
+
+      expect(result.success).toBe(true);
+      expect(otpRepo.createOtp).not.toHaveBeenCalled();
+      expect(mockEmailService.sendEmail).not.toHaveBeenCalled();
+    });
+
+    it("should send OTP for a known admin email", async () => {
+      vi.mocked(otpRepo.countRecentOtps).mockResolvedValue(0);
+      vi.mocked(otpRepo.deleteExpiredOtps).mockResolvedValue({ count: 0 });
+      vi.mocked(otpRepo.createOtp).mockResolvedValue({} as never);
+      (mockEmailService.sendEmail as ReturnType<typeof vi.fn>).mockResolvedValue({
+        success: true,
+        messageId: "msg-1",
+      } as EmailResult);
+
+      const result = await adminOtpService.requestOtp("admin@example.com");
+
+      expect(result.success).toBe(true);
+      expect(otpRepo.createOtp).toHaveBeenCalled();
+      expect(mockEmailService.sendEmail).toHaveBeenCalledWith(
+        expect.objectContaining({ to: "admin@example.com" }),
+        undefined,
+      );
+    });
+
+    it("should use a 6-digit OTP code in the email", async () => {
+      vi.mocked(otpRepo.countRecentOtps).mockResolvedValue(0);
+      vi.mocked(otpRepo.deleteExpiredOtps).mockResolvedValue({ count: 0 });
+      vi.mocked(otpRepo.createOtp).mockResolvedValue({} as never);
+      (mockEmailService.sendEmail as ReturnType<typeof vi.fn>).mockResolvedValue({
+        success: true,
+        messageId: "msg-1",
+      } as EmailResult);
+
+      await adminOtpService.requestOtp("admin@example.com");
+
+      const [, code] = vi.mocked(otpRepo.createOtp).mock.calls[0];
+      expect(Number.isInteger(code)).toBe(true);
+      expect(code).toBeGreaterThanOrEqual(100000);
+      expect(code).toBeLessThan(1000000);
+    });
+
+    it("should return 429 when rate limit is exceeded", async () => {
+      const oldestOtpTime = new Date("2024-01-01T11:55:00Z");
+      vi.mocked(otpRepo.countRecentOtps).mockResolvedValue(3);
+      vi.mocked(otpRepo.findOldestRecentOtp).mockResolvedValue({
+        id: "otp-1",
+        email: "admin@example.com",
+        code: 123456,
+        expiresAt: new Date(),
+        createdAt: oldestOtpTime,
+      });
+
+      const result = await adminOtpService.requestOtp("admin@example.com");
+
+      expect(result.success).toBe(false);
+      expect(result.statusCode).toBe(429);
+      expect(result.retryAfter).toBe(300); // 5 minutes remaining
+    });
+
+    it("should return 500 when email sending fails", async () => {
+      vi.mocked(otpRepo.countRecentOtps).mockResolvedValue(0);
+      vi.mocked(otpRepo.deleteExpiredOtps).mockResolvedValue({ count: 0 });
+      vi.mocked(otpRepo.createOtp).mockResolvedValue({} as never);
+      (mockEmailService.sendEmail as ReturnType<typeof vi.fn>).mockResolvedValue({
+        success: false,
+        error: "SMTP timeout",
+      } as EmailResult);
+
+      const result = await adminOtpService.requestOtp("admin@example.com");
+
+      expect(result.success).toBe(false);
+      expect(result.statusCode).toBe(500);
+      expect(result.error).toBe("Failed to send email");
+    });
+
+    it("should return 500 on unexpected DB error", async () => {
+      vi.mocked(otpRepo.countRecentOtps).mockRejectedValue(new Error("DB down"));
+
+      const result = await adminOtpService.requestOtp("admin@example.com");
+
+      expect(result.success).toBe(false);
+      expect(result.statusCode).toBe(500);
+      expect(result.error).toBe("Internal server error");
+    });
+  });
+
+  describe("AdminOtpService.verifyOtp", () => {
+    it("should verify valid OTP and create an admin session", async () => {
+      vi.mocked(otpRepo.findValidOtp).mockResolvedValue({
+        id: "otp-1",
+        email: "admin@example.com",
+        code: 123456,
+        expiresAt: new Date("2024-01-01T12:10:00Z"),
+        createdAt: new Date("2024-01-01T12:00:00Z"),
+      });
+      vi.mocked(otpRepo.deleteAllOtpsByEmail).mockResolvedValue({ count: 1 });
+
+      const result = await adminOtpService.verifyOtp("admin@example.com", 123456);
+
+      expect(result.success).toBe(true);
+      expect(result.sessionToken).toBeDefined();
+      expect(result.sessionToken).toHaveLength(128);
+      expect(result.adminUser).toMatchObject({ email: "admin@example.com" });
+    });
+
+    it("should delete all OTPs for the email after successful verification", async () => {
+      vi.mocked(otpRepo.findValidOtp).mockResolvedValue({
+        id: "otp-1",
+        email: "admin@example.com",
+        code: 123456,
+        expiresAt: new Date("2024-01-01T12:10:00Z"),
+        createdAt: new Date(),
+      });
+      vi.mocked(otpRepo.deleteAllOtpsByEmail).mockResolvedValue({ count: 1 });
+
+      await adminOtpService.verifyOtp("admin@example.com", 123456);
+
+      expect(otpRepo.deleteAllOtpsByEmail).toHaveBeenCalledWith(
+        "admin@example.com",
+        expect.anything(),
+      );
+    });
+
+    it("should return 401 when OTP is invalid or expired", async () => {
+      vi.mocked(otpRepo.findValidOtp).mockResolvedValue(null);
+
+      const result = await adminOtpService.verifyOtp("admin@example.com", 999999);
+
+      expect(result.success).toBe(false);
+      expect(result.statusCode).toBe(401);
+      expect(result.error).toBe("Invalid or expired OTP");
+      expect(adminRepo.createAdminSession).not.toHaveBeenCalled();
+    });
+
+    it("should return 401 when OTP matches but email is not an admin", async () => {
+      vi.mocked(otpRepo.findValidOtp).mockResolvedValue({
+        id: "otp-1",
+        email: "regular@example.com",
+        code: 123456,
+        expiresAt: new Date("2024-01-01T12:10:00Z"),
+        createdAt: new Date(),
+      });
+      vi.mocked(otpRepo.deleteAllOtpsByEmail).mockResolvedValue({ count: 1 });
+      vi.mocked(adminRepo.findAdminUserByEmail).mockResolvedValue(null);
+
+      const result = await adminOtpService.verifyOtp("regular@example.com", 123456);
+
+      expect(result.success).toBe(false);
+      expect(result.statusCode).toBe(401);
+      expect(adminRepo.createAdminSession).not.toHaveBeenCalled();
+    });
+
+    it("should rotate sessions — delete old sessions before creating new one", async () => {
+      vi.mocked(otpRepo.findValidOtp).mockResolvedValue({
+        id: "otp-1",
+        email: "admin@example.com",
+        code: 123456,
+        expiresAt: new Date("2024-01-01T12:10:00Z"),
+        createdAt: new Date(),
+      });
+      vi.mocked(otpRepo.deleteAllOtpsByEmail).mockResolvedValue({ count: 1 });
+
+      await adminOtpService.verifyOtp("admin@example.com", 123456);
+
+      expect(adminRepo.deleteAdminUserSessions).toHaveBeenCalledWith("admin-1");
+      expect(adminRepo.createAdminSession).toHaveBeenCalled();
+
+      const deleteOrder = vi.mocked(adminRepo.deleteAdminUserSessions).mock.invocationCallOrder[0];
+      const createOrder = vi.mocked(adminRepo.createAdminSession).mock.invocationCallOrder[0];
+      expect(deleteOrder).toBeLessThan(createOrder);
+    });
+
+    it("should return 500 on unexpected DB error during verification", async () => {
+      vi.mocked(otpRepo.findValidOtp).mockRejectedValue(new Error("DB error"));
+
+      const result = await adminOtpService.verifyOtp("admin@example.com", 123456);
+
+      expect(result.success).toBe(false);
+      expect(result.statusCode).toBe(500);
+      expect(result.error).toBe("Internal server error");
+    });
+  });
+});

--- a/src/__tests__/adminOtp.test.ts
+++ b/src/__tests__/adminOtp.test.ts
@@ -9,8 +9,15 @@ import * as adminOtpServiceModule from "../services/adminOtpService";
 import { AdminOtpService } from "../services/adminOtpService";
 import * as otpRepo from "../repo/otpRepo";
 import * as adminRepo from "../repo/adminRepo";
+import { withTransaction } from "../repo/db";
 import type { EmailService } from "../services/email/emailService";
 import type { EmailResult } from "../services/email/types";
+import { randomInt } from "crypto";
+
+vi.mock("crypto", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("crypto")>();
+  return { ...actual, randomInt: vi.fn(actual.randomInt) };
+});
 
 // ── Repo mocks ──────────────────────────────────────────────────────────────
 
@@ -337,7 +344,7 @@ describe("Admin OTP API", () => {
   // ── AdminOtpService unit tests ─────────────────────────────────────────────
 
   describe("AdminOtpService.requestOtp", () => {
-    it("should silently succeed for non-admin email without sending OTP", async () => {
+    it("should record an OTP attempt for a non-admin email without sending an email", async () => {
       vi.mocked(adminRepo.findAdminUserByEmail).mockResolvedValue(null);
       vi.mocked(otpRepo.countRecentOtps).mockResolvedValue(0);
       vi.mocked(otpRepo.deleteExpiredOtps).mockResolvedValue({ count: 0 });
@@ -345,7 +352,11 @@ describe("Admin OTP API", () => {
       const result = await adminOtpService.requestOtp("nobody@example.com");
 
       expect(result.success).toBe(true);
-      expect(otpRepo.createOtp).not.toHaveBeenCalled();
+      expect(otpRepo.createOtp).toHaveBeenCalledWith(
+        "nobody@example.com",
+        expect.any(Number),
+        expect.any(Date),
+      );
       expect(mockEmailService.sendEmail).not.toHaveBeenCalled();
     });
 
@@ -383,6 +394,20 @@ describe("Admin OTP API", () => {
       expect(Number.isInteger(code)).toBe(true);
       expect(code).toBeGreaterThanOrEqual(100000);
       expect(code).toBeLessThan(1000000);
+    });
+
+    it("should include 999999 in the generated OTP range", async () => {
+      vi.mocked(otpRepo.countRecentOtps).mockResolvedValue(0);
+      vi.mocked(otpRepo.deleteExpiredOtps).mockResolvedValue({ count: 0 });
+      vi.mocked(otpRepo.createOtp).mockResolvedValue({} as never);
+      (mockEmailService.sendEmail as ReturnType<typeof vi.fn>).mockResolvedValue({
+        success: true,
+        messageId: "msg-1",
+      } as EmailResult);
+
+      await adminOtpService.requestOtp("admin@example.com");
+
+      expect(randomInt).toHaveBeenCalledWith(100000, 1000000);
     });
 
     it("should return 429 when rate limit is exceeded", async () => {
@@ -432,6 +457,10 @@ describe("Admin OTP API", () => {
 
   describe("AdminOtpService.verifyOtp", () => {
     it("should verify valid OTP and create an admin session", async () => {
+      const transactionClient = {};
+      vi.mocked(withTransaction).mockImplementationOnce(async (callback) =>
+        callback(transactionClient as never),
+      );
       vi.mocked(otpRepo.findValidOtp).mockResolvedValue({
         id: "otp-1",
         email: "admin@example.com",
@@ -447,6 +476,15 @@ describe("Admin OTP API", () => {
       expect(result.sessionToken).toBeDefined();
       expect(result.sessionToken).toHaveLength(128);
       expect(result.adminUser).toMatchObject({ email: "admin@example.com" });
+      expect(otpRepo.deleteAllOtpsByEmail).toHaveBeenCalledWith("admin@example.com", transactionClient);
+      expect(adminRepo.findAdminUserByEmail).toHaveBeenCalledWith("admin@example.com", transactionClient);
+      expect(adminRepo.deleteAdminUserSessions).toHaveBeenCalledWith("admin-1", transactionClient);
+      expect(adminRepo.createAdminSession).toHaveBeenCalledWith(
+        expect.any(String),
+        "admin-1",
+        expect.any(Date),
+        transactionClient,
+      );
     });
 
     it("should delete all OTPs for the email after successful verification", async () => {
@@ -508,7 +546,7 @@ describe("Admin OTP API", () => {
 
       await adminOtpService.verifyOtp("admin@example.com", 123456);
 
-      expect(adminRepo.deleteAdminUserSessions).toHaveBeenCalledWith("admin-1");
+      expect(adminRepo.deleteAdminUserSessions).toHaveBeenCalledWith("admin-1", expect.anything());
       expect(adminRepo.createAdminSession).toHaveBeenCalled();
 
       const deleteOrder = vi.mocked(adminRepo.deleteAdminUserSessions).mock.invocationCallOrder[0];

--- a/src/__tests__/adminRoutingMiddleware.test.ts
+++ b/src/__tests__/adminRoutingMiddleware.test.ts
@@ -6,19 +6,43 @@ import {
   ADMIN_SESSION_TOKEN_COOKIE_NAME,
   signAdminSessionCookie,
 } from "../lib/adminSessionCookieSig";
+import { SESSION_SIG_COOKIE_NAME, signSessionCookie } from "../lib/sessionCookieSig";
 
 const ADMIN_PATH = "e2e-admin-portal";
 const ADMIN_SESSION_SECRET = "test-admin-secret-for-middleware-tests-123456";
+const SESSION_SECRET = "test-session-secret-for-middleware-tests-123456";
+
+const createRequest = (path: string, cookie?: string) =>
+  new NextRequest(`http://localhost${path}`, {
+    headers: cookie ? { cookie } : undefined,
+  });
 
 describe("admin portal middleware routing", () => {
   beforeEach(() => {
     process.env.ADMIN_PATH = ADMIN_PATH;
     process.env.ADMIN_SESSION_COOKIE_SECRET = ADMIN_SESSION_SECRET;
+    process.env.SESSION_COOKIE_SECRET = SESSION_SECRET;
   });
 
   afterEach(() => {
     delete process.env.ADMIN_PATH;
     delete process.env.ADMIN_SESSION_COOKIE_SECRET;
+    delete process.env.SESSION_COOKIE_SECRET;
+  });
+
+  it.each(["/api/health", "/_next/static/chunk.js"])(
+    "bypasses middleware for %s",
+    async (path) => {
+      const response = await middleware(createRequest(path));
+
+      expect(response.headers.get("x-middleware-next")).toBe("1");
+    },
+  );
+
+  it.each(["/portal", "/portal/login"])("blocks direct internal portal path %s", async (path) => {
+    const response = await middleware(createRequest(path));
+
+    expect(response.headers.get("location")).toBe("http://localhost/");
   });
 
   it("redirects an unauthenticated bare admin path to login", async () => {
@@ -44,5 +68,109 @@ describe("admin portal middleware routing", () => {
     const response = await middleware(request);
 
     expect(response.headers.get("location")).toBe(`http://localhost/${ADMIN_PATH}/dashboard`);
+  });
+
+  it("redirects an unauthenticated admin dashboard request to login", async () => {
+    const response = await middleware(createRequest(`/${ADMIN_PATH}/dashboard`));
+
+    expect(response.headers.get("location")).toBe(`http://localhost/${ADMIN_PATH}/login`);
+  });
+
+  it("treats an admin session as unauthenticated when its signing secret is unavailable", async () => {
+    delete process.env.ADMIN_SESSION_COOKIE_SECRET;
+
+    const response = await middleware(
+      createRequest(
+        `/${ADMIN_PATH}/dashboard`,
+        `${ADMIN_SESSION_TOKEN_COOKIE_NAME}=token; ${ADMIN_SESSION_SIG_COOKIE_NAME}=signature`,
+      ),
+    );
+
+    expect(response.headers.get("location")).toBe(`http://localhost/${ADMIN_PATH}/login`);
+  });
+
+  it("redirects an authenticated admin login request to the dashboard", async () => {
+    const sessionToken = "admin-login-session-token";
+    const sessionSig = await signAdminSessionCookie(
+      sessionToken,
+      new Date(Date.now() + 60 * 60 * 1000),
+    );
+
+    const response = await middleware(
+      createRequest(
+        `/${ADMIN_PATH}/login`,
+        `${ADMIN_SESSION_TOKEN_COOKIE_NAME}=${sessionToken}; ${ADMIN_SESSION_SIG_COOKIE_NAME}=${sessionSig}`,
+      ),
+    );
+
+    expect(response.headers.get("location")).toBe(`http://localhost/${ADMIN_PATH}/dashboard`);
+  });
+
+  it("rewrites a permitted admin route to its internal portal path", async () => {
+    const response = await middleware(createRequest(`/${ADMIN_PATH}/reports`));
+
+    expect(response.headers.get("x-middleware-rewrite")).toBe(
+      `http://localhost/portal/reports`,
+    );
+  });
+
+  it("allows public regular routes", async () => {
+    const response = await middleware(createRequest("/about"));
+
+    expect(response.headers.get("x-middleware-next")).toBe("1");
+  });
+
+  it("redirects unauthenticated protected regular routes to login with the return URL", async () => {
+    const response = await middleware(createRequest("/dashboard?tab=tasks"));
+
+    expect(response.headers.get("location")).toBe(
+      "http://localhost/login?redirect=%2Fdashboard%3Ftab%3Dtasks",
+    );
+  });
+
+  it("allows authenticated protected regular routes", async () => {
+    const sessionToken = "regular-dashboard-session-token";
+    const sessionSig = await signSessionCookie(
+      sessionToken,
+      new Date(Date.now() + 60 * 60 * 1000),
+    );
+
+    const response = await middleware(
+      createRequest("/profile", `session_token=${sessionToken}; ${SESSION_SIG_COOKIE_NAME}=${sessionSig}`),
+    );
+
+    expect(response.headers.get("x-middleware-next")).toBe("1");
+  });
+
+  it("treats a regular session as unauthenticated when its signing secret is unavailable", async () => {
+    delete process.env.SESSION_COOKIE_SECRET;
+
+    const response = await middleware(
+      createRequest("/dashboard", `session_token=token; ${SESSION_SIG_COOKIE_NAME}=signature`),
+    );
+
+    expect(response.headers.get("location")).toBe(
+      "http://localhost/login?redirect=%2Fdashboard",
+    );
+  });
+
+  it("redirects an authenticated regular user away from login", async () => {
+    const sessionToken = "regular-login-session-token";
+    const sessionSig = await signSessionCookie(
+      sessionToken,
+      new Date(Date.now() + 60 * 60 * 1000),
+    );
+
+    const response = await middleware(
+      createRequest("/login", `session_token=${sessionToken}; ${SESSION_SIG_COOKIE_NAME}=${sessionSig}`),
+    );
+
+    expect(response.headers.get("location")).toBe("http://localhost/dashboard");
+  });
+
+  it("allows an unauthenticated regular login request", async () => {
+    const response = await middleware(createRequest("/login"));
+
+    expect(response.headers.get("x-middleware-next")).toBe("1");
   });
 });

--- a/src/__tests__/adminRoutingMiddleware.test.ts
+++ b/src/__tests__/adminRoutingMiddleware.test.ts
@@ -1,0 +1,48 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { NextRequest } from "next/server";
+import { middleware } from "../../middleware";
+import {
+  ADMIN_SESSION_SIG_COOKIE_NAME,
+  ADMIN_SESSION_TOKEN_COOKIE_NAME,
+  signAdminSessionCookie,
+} from "../lib/adminSessionCookieSig";
+
+const ADMIN_PATH = "e2e-admin-portal";
+const ADMIN_SESSION_SECRET = "test-admin-secret-for-middleware-tests-123456";
+
+describe("admin portal middleware routing", () => {
+  beforeEach(() => {
+    process.env.ADMIN_PATH = ADMIN_PATH;
+    process.env.ADMIN_SESSION_COOKIE_SECRET = ADMIN_SESSION_SECRET;
+  });
+
+  afterEach(() => {
+    delete process.env.ADMIN_PATH;
+    delete process.env.ADMIN_SESSION_COOKIE_SECRET;
+  });
+
+  it("redirects an unauthenticated bare admin path to login", async () => {
+    const request = new NextRequest(`http://localhost/${ADMIN_PATH}`);
+
+    const response = await middleware(request);
+
+    expect(response.headers.get("location")).toBe(`http://localhost/${ADMIN_PATH}/login`);
+  });
+
+  it("redirects an authenticated bare admin path to the dashboard", async () => {
+    const sessionToken = "admin-session-token";
+    const sessionSig = await signAdminSessionCookie(
+      sessionToken,
+      new Date(Date.now() + 60 * 60 * 1000),
+    );
+    const request = new NextRequest(`http://localhost/${ADMIN_PATH}`, {
+      headers: {
+        cookie: `${ADMIN_SESSION_TOKEN_COOKIE_NAME}=${sessionToken}; ${ADMIN_SESSION_SIG_COOKIE_NAME}=${sessionSig}`,
+      },
+    });
+
+    const response = await middleware(request);
+
+    expect(response.headers.get("location")).toBe(`http://localhost/${ADMIN_PATH}/dashboard`);
+  });
+});

--- a/src/__tests__/openApiOperationIds.test.ts
+++ b/src/__tests__/openApiOperationIds.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from "vitest";
+import swagger from "../generated/swagger.json";
+
+type OpenApiOperation = { operationId?: string };
+
+describe("OpenAPI specification", () => {
+  it("uses a unique operationId for every operation", () => {
+    const operationIds = Object.values(swagger.paths).flatMap((pathItem) =>
+      Object.values(pathItem as Record<string, OpenApiOperation>)
+        .map((operation) => operation.operationId)
+        .filter((operationId): operationId is string => operationId !== undefined),
+    );
+
+    expect(new Set(operationIds).size).toBe(operationIds.length);
+  });
+});

--- a/src/__tests__/otp.test.ts
+++ b/src/__tests__/otp.test.ts
@@ -425,7 +425,7 @@ describe("OTP API", () => {
 
       expect(result.success).toBe(true);
       // Verify rate limit window only counts OTPs from last 10 minutes
-      expect(otpRepo.countRecentOtps).toHaveBeenCalledWith(testEmail, windowStartTime);
+      expect(otpRepo.countRecentOtps).toHaveBeenCalledWith(testEmail, windowStartTime, "USER");
     });
 
     it("should count OTPs from last 10 minutes only", async () => {
@@ -442,7 +442,7 @@ describe("OTP API", () => {
 
       await otpService.requestOtp(testEmail);
 
-      expect(otpRepo.countRecentOtps).toHaveBeenCalledWith(testEmail, tenMinutesAgo);
+      expect(otpRepo.countRecentOtps).toHaveBeenCalledWith(testEmail, tenMinutesAgo, "USER");
     });
   });
 
@@ -460,7 +460,7 @@ describe("OTP API", () => {
 
       await otpService.requestOtp(testEmail);
 
-      expect(otpRepo.deleteExpiredOtps).toHaveBeenCalledWith(testEmail);
+      expect(otpRepo.deleteExpiredOtps).toHaveBeenCalledWith(testEmail, "USER");
 
       // Verify deletion happens before creation
       const deleteCall = vi.mocked(otpRepo.deleteExpiredOtps).mock.invocationCallOrder[0];
@@ -545,6 +545,7 @@ describe("OTP API", () => {
         testEmail,
         expect.any(Number),
         expect.any(Date),
+        "USER",
       );
     });
   });
@@ -835,8 +836,8 @@ describe("OTP API", () => {
       const result = await otpService.verifyOtp(testEmail, 123456);
 
       expect(result.success).toBe(true);
-      expect(otpRepo.findValidOtp).toHaveBeenCalledWith(testEmail, 123456);
-      expect(otpRepo.deleteAllOtpsByEmail).toHaveBeenCalledWith(testEmail, expect.anything());
+      expect(otpRepo.findValidOtp).toHaveBeenCalledWith(testEmail, 123456, "USER");
+      expect(otpRepo.deleteAllOtpsByEmail).toHaveBeenCalledWith(testEmail, "USER", expect.anything());
       expect(sessionRepo.deleteUserSessions).toHaveBeenCalledWith("user-1", expect.anything());
       const [sessionToken] = vi.mocked(sessionRepo.createSession).mock.calls[0];
       expect(sessionToken).toHaveLength(128);

--- a/src/__tests__/otpTestPeek.test.ts
+++ b/src/__tests__/otpTestPeek.test.ts
@@ -77,6 +77,6 @@ describe('GET /otp/test-peek (test-only endpoint)', () => {
 
     await request(app).get('/otp/test-peek?email=User@EXAMPLE.COM');
 
-    expect(otpRepo.findLatestValidOtp).toHaveBeenCalledWith('user@example.com');
+    expect(otpRepo.findLatestValidOtp).toHaveBeenCalledWith('user@example.com', 'USER');
   });
 });

--- a/src/__tests__/repo/otpRepo.test.ts
+++ b/src/__tests__/repo/otpRepo.test.ts
@@ -28,10 +28,10 @@ describe("otpRepo", () => {
     it("counts OTP records created at or after the window start time", async () => {
       vi.mocked(prisma.oTPCode.count).mockResolvedValue(2);
       const windowStart = new Date("2024-01-01T11:50:00Z");
-      const result = await otpRepo.countRecentOtps("user@example.com", windowStart);
+      const result = await otpRepo.countRecentOtps("user@example.com", windowStart, "USER");
       expect(result).toBe(2);
       expect(prisma.oTPCode.count).toHaveBeenCalledWith({
-        where: { email: "user@example.com", createdAt: { gte: windowStart } },
+        where: { email: "user@example.com", purpose: "USER", createdAt: { gte: windowStart } },
       });
     });
   });
@@ -41,10 +41,10 @@ describe("otpRepo", () => {
       const oldestOtp = { id: "otp-1", email: "user@example.com", code: 123456, expiresAt: new Date(), createdAt: new Date("2024-01-01T11:51:00Z") };
       vi.mocked(prisma.oTPCode.findFirst).mockResolvedValue(oldestOtp);
       const windowStart = new Date("2024-01-01T11:50:00Z");
-      const result = await otpRepo.findOldestRecentOtp("user@example.com", windowStart);
+      const result = await otpRepo.findOldestRecentOtp("user@example.com", windowStart, "USER");
       expect(result).toBe(oldestOtp);
       expect(prisma.oTPCode.findFirst).toHaveBeenCalledWith({
-        where: { email: "user@example.com", createdAt: { gte: windowStart } },
+        where: { email: "user@example.com", purpose: "USER", createdAt: { gte: windowStart } },
         orderBy: { createdAt: "asc" },
       });
     });
@@ -53,9 +53,9 @@ describe("otpRepo", () => {
   describe("deleteExpiredOtps", () => {
     it("deletes OTPs whose expiresAt is before now", async () => {
       vi.mocked(prisma.oTPCode.deleteMany).mockResolvedValue({ count: 1 });
-      await otpRepo.deleteExpiredOtps("user@example.com");
+      await otpRepo.deleteExpiredOtps("user@example.com", "USER");
       expect(prisma.oTPCode.deleteMany).toHaveBeenCalledWith({
-        where: { email: "user@example.com", expiresAt: { lt: new Date("2024-01-01T12:00:00Z") } },
+        where: { email: "user@example.com", purpose: "USER", expiresAt: { lt: new Date("2024-01-01T12:00:00Z") } },
       });
     });
   });
@@ -64,9 +64,9 @@ describe("otpRepo", () => {
     it("creates an OTP record with the given email, code, and expiry", async () => {
       vi.mocked(prisma.oTPCode.create).mockResolvedValue({} as never);
       const expiresAt = new Date("2024-01-01T12:10:00Z");
-      await otpRepo.createOtp("user@example.com", 123456, expiresAt);
+      await otpRepo.createOtp("user@example.com", 123456, expiresAt, "USER");
       expect(prisma.oTPCode.create).toHaveBeenCalledWith({
-        data: { email: "user@example.com", code: 123456, expiresAt },
+        data: { email: "user@example.com", code: 123456, expiresAt, purpose: "USER" },
       });
     });
   });
@@ -75,12 +75,13 @@ describe("otpRepo", () => {
     it("finds an OTP that is not yet expired", async () => {
       const record = { id: "otp-1", email: "user@example.com", code: 123456, expiresAt: new Date("2024-01-01T12:10:00Z"), createdAt: new Date() };
       vi.mocked(prisma.oTPCode.findFirst).mockResolvedValue(record);
-      const result = await otpRepo.findValidOtp("user@example.com", 123456);
+      const result = await otpRepo.findValidOtp("user@example.com", 123456, "ADMIN");
       expect(result).toBe(record);
       expect(prisma.oTPCode.findFirst).toHaveBeenCalledWith({
         where: {
           email: "user@example.com",
           code: 123456,
+          purpose: "ADMIN",
           expiresAt: { gt: new Date("2024-01-01T12:00:00Z") },
         },
       });
@@ -88,7 +89,7 @@ describe("otpRepo", () => {
 
     it("returns null when no matching valid OTP exists", async () => {
       vi.mocked(prisma.oTPCode.findFirst).mockResolvedValue(null);
-      const result = await otpRepo.findValidOtp("user@example.com", 999999);
+      const result = await otpRepo.findValidOtp("user@example.com", 999999, "USER");
       expect(result).toBeNull();
     });
   });
@@ -96,15 +97,15 @@ describe("otpRepo", () => {
   describe("deleteAllOtpsByEmail", () => {
     it("deletes all OTPs for the given email regardless of expiry", async () => {
       vi.mocked(prisma.oTPCode.deleteMany).mockResolvedValue({ count: 3 });
-      await otpRepo.deleteAllOtpsByEmail("user@example.com");
+      await otpRepo.deleteAllOtpsByEmail("user@example.com", "USER");
       expect(prisma.oTPCode.deleteMany).toHaveBeenCalledWith({
-        where: { email: "user@example.com" },
+        where: { email: "user@example.com", purpose: "USER" },
       });
     });
 
     it("accepts a custom db instance", async () => {
       const mockDb = { oTPCode: { deleteMany: vi.fn().mockResolvedValue({ count: 0 }) } };
-      await otpRepo.deleteAllOtpsByEmail("user@example.com", mockDb as Parameters<typeof otpRepo.deleteAllOtpsByEmail>[1]);
+      await otpRepo.deleteAllOtpsByEmail("user@example.com", "USER", mockDb as Parameters<typeof otpRepo.deleteAllOtpsByEmail>[2]);
       expect(mockDb.oTPCode.deleteMany).toHaveBeenCalled();
       expect(prisma.oTPCode.deleteMany).not.toHaveBeenCalled();
     });

--- a/src/app/api/admin/auth/logout/route.ts
+++ b/src/app/api/admin/auth/logout/route.ts
@@ -1,0 +1,29 @@
+import { NextRequest, NextResponse } from "next/server";
+import { randomUUID } from "crypto";
+import { createChildLogger } from "@/lib/logger";
+import { API_BASE_URL } from "@/lib/config";
+import { clearAdminSessionCookies } from "@/lib/adminSessionCookieSig";
+
+export async function POST(request: NextRequest) {
+  const requestId = randomUUID();
+  const logger = createChildLogger({ requestId, route: "/api/admin/auth/logout" });
+
+  try {
+    const cookie = request.headers.get("cookie");
+    const response = await fetch(`${API_BASE_URL}/admin/auth/logout`, {
+      method: "POST",
+      headers: {
+        "X-Request-ID": requestId,
+        ...(cookie ? { Cookie: cookie } : {}),
+      },
+    });
+
+    const data = await response.json();
+    const nextResponse = NextResponse.json(data, { status: response.status });
+    clearAdminSessionCookies(nextResponse);
+    return nextResponse;
+  } catch (error: unknown) {
+    logger.error({ err: error, msg: "Failed to logout admin" });
+    return NextResponse.json({ error: "Failed to logout" }, { status: 500 });
+  }
+}

--- a/src/app/api/admin/auth/session/route.ts
+++ b/src/app/api/admin/auth/session/route.ts
@@ -1,0 +1,32 @@
+import { NextRequest, NextResponse } from "next/server";
+import { randomUUID } from "crypto";
+import { createChildLogger } from "@/lib/logger";
+import { API_BASE_URL } from "@/lib/config";
+import { clearAdminSessionCookies } from "@/lib/adminSessionCookieSig";
+
+export async function GET(request: NextRequest) {
+  const requestId = randomUUID();
+  const logger = createChildLogger({ requestId, route: "/api/admin/auth/session" });
+
+  try {
+    const cookie = request.headers.get("cookie");
+    const response = await fetch(`${API_BASE_URL}/admin/auth/session`, {
+      headers: {
+        "X-Request-ID": requestId,
+        ...(cookie ? { Cookie: cookie } : {}),
+      },
+    });
+
+    const data = await response.json();
+    const nextResponse = NextResponse.json(data, { status: response.status });
+
+    if (response.status === 401) {
+      clearAdminSessionCookies(nextResponse);
+    }
+
+    return nextResponse;
+  } catch (error: unknown) {
+    logger.error({ err: error, msg: "Error fetching admin session" });
+    return NextResponse.json({ error: "Failed to fetch admin session" }, { status: 500 });
+  }
+}

--- a/src/app/api/admin/otp/generate/route.ts
+++ b/src/app/api/admin/otp/generate/route.ts
@@ -1,0 +1,32 @@
+import { NextRequest, NextResponse } from "next/server";
+import { randomUUID } from "crypto";
+import { createChildLogger } from "@/lib/logger";
+import { API_BASE_URL } from "@/lib/config";
+import { forwardRateLimitHeaders } from "@/app/api/otp/routeHelpers";
+
+export async function POST(request: NextRequest) {
+  const requestId = randomUUID();
+  const logger = createChildLogger({ requestId, route: "/api/admin/otp/generate" });
+
+  try {
+    const body = await request.json();
+    logger.info({ msg: "Forwarding admin OTP generate request to Express" });
+
+    const response = await fetch(`${API_BASE_URL}/admin/otp/generate`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "X-Request-ID": requestId,
+      },
+      body: JSON.stringify(body),
+    });
+
+    const data = await response.json();
+    const nextResponse = NextResponse.json(data, { status: response.status });
+    forwardRateLimitHeaders(response, nextResponse);
+    return nextResponse;
+  } catch (error: unknown) {
+    logger.error({ err: error, msg: "Error in admin OTP generate route" });
+    return NextResponse.json({ error: "Failed to send admin OTP" }, { status: 500 });
+  }
+}

--- a/src/app/api/admin/otp/verify/route.ts
+++ b/src/app/api/admin/otp/verify/route.ts
@@ -1,0 +1,61 @@
+import { NextRequest, NextResponse } from "next/server";
+import { randomUUID } from "crypto";
+import { createChildLogger } from "@/lib/logger";
+import { API_BASE_URL } from "@/lib/config";
+import {
+  ADMIN_SESSION_TOKEN_COOKIE_NAME,
+  ADMIN_SESSION_SIG_COOKIE_NAME,
+  signAdminSessionCookie,
+} from "@/lib/adminSessionCookieSig";
+
+const ADMIN_SESSION_MAX_AGE_SECONDS = 7 * 24 * 60 * 60;
+
+export async function POST(request: NextRequest) {
+  const requestId = randomUUID();
+  const logger = createChildLogger({ requestId, route: "/api/admin/otp/verify" });
+
+  try {
+    const body = await request.json();
+    logger.info({ msg: "Forwarding admin OTP verification request to Express" });
+
+    const response = await fetch(`${API_BASE_URL}/admin/otp/verify`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "X-Request-ID": requestId,
+      },
+      body: JSON.stringify(body),
+    });
+
+    const data = await response.json();
+    const responseBody = { ...data };
+
+    if (response.ok && responseBody.success && responseBody.sessionToken) {
+      const sessionToken = responseBody.sessionToken;
+      delete responseBody.sessionToken;
+
+      const nextResponse = NextResponse.json(responseBody, { status: response.status });
+
+      const cookieOptions = {
+        httpOnly: true,
+        secure: process.env.NODE_ENV === "production",
+        sameSite: "lax" as const,
+        path: "/",
+        maxAge: ADMIN_SESSION_MAX_AGE_SECONDS,
+      };
+
+      nextResponse.cookies.set(ADMIN_SESSION_TOKEN_COOKIE_NAME, sessionToken, cookieOptions);
+
+      const expiresAt = new Date(Date.now() + ADMIN_SESSION_MAX_AGE_SECONDS * 1000);
+      const sessionSig = await signAdminSessionCookie(sessionToken, expiresAt);
+      nextResponse.cookies.set(ADMIN_SESSION_SIG_COOKIE_NAME, sessionSig, cookieOptions);
+
+      return nextResponse;
+    }
+
+    return NextResponse.json(responseBody, { status: response.status });
+  } catch (error: unknown) {
+    logger.error({ err: error, msg: "Error in admin OTP verify route" });
+    return NextResponse.json({ error: "Failed to verify admin OTP" }, { status: 500 });
+  }
+}

--- a/src/app/portal/dashboard/page.tsx
+++ b/src/app/portal/dashboard/page.tsx
@@ -1,0 +1,12 @@
+export default function AdminDashboardPage() {
+  return (
+    <main className="min-h-screen bg-background p-8">
+      <div className="mx-auto max-w-4xl">
+        <h1 className="text-2xl font-semibold text-foreground">Admin Portal</h1>
+        <p className="mt-2 text-muted-foreground">
+          Stats and management features are coming soon.
+        </p>
+      </div>
+    </main>
+  );
+}

--- a/src/app/portal/layout.tsx
+++ b/src/app/portal/layout.tsx
@@ -1,0 +1,10 @@
+import type { Metadata } from "next";
+
+export const metadata: Metadata = {
+  title: "Admin Portal",
+  robots: { index: false, follow: false },
+};
+
+export default function AdminPortalLayout({ children }: { children: React.ReactNode }) {
+  return <>{children}</>;
+}

--- a/src/app/portal/login/page.tsx
+++ b/src/app/portal/login/page.tsx
@@ -1,0 +1,6 @@
+import { AdminLoginForm } from "@/components/AdminLoginForm";
+
+export default function AdminLoginPage() {
+  const adminPath = process.env.ADMIN_PATH ?? "";
+  return <AdminLoginForm adminPath={adminPath} />;
+}

--- a/src/components/AdminLoginForm.tsx
+++ b/src/components/AdminLoginForm.tsx
@@ -29,7 +29,12 @@ export function AdminLoginForm({ adminPath }: AdminLoginFormProps) {
   const [successMessage, setSuccessMessage] = useState("");
   const [resendCooldown, setResendCooldown] = useState(0);
 
-  const dashboardUrl = adminPath ? `/${adminPath}/dashboard` : "/portal/dashboard";
+  // Derive the dashboard URL from the current URL path so it stays consistent
+  // regardless of how ADMIN_PATH is set on the server at build vs. runtime.
+  // pathname is e.g. "/e2e-admin-portal/login" → base is "/e2e-admin-portal"
+  const { pathname } = typeof window !== "undefined" ? window.location : { pathname: adminPath ? `/${adminPath}/login` : "/portal/login" };
+  const adminBase = pathname.replace(/\/login\/?$/, "");
+  const dashboardUrl = `${adminBase}/dashboard`;
 
   useEffect(() => {
     if (resendCooldown > 0) {

--- a/src/components/AdminLoginForm.tsx
+++ b/src/components/AdminLoginForm.tsx
@@ -1,0 +1,238 @@
+"use client";
+
+import { useState, useEffect } from "react";
+import { useRouter } from "next/navigation";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import {
+  Card,
+  CardHeader,
+  CardTitle,
+  CardDescription,
+  CardContent,
+} from "@/components/ui/card";
+import { EMAIL_REGEX } from "@/lib/utils";
+
+interface AdminLoginFormProps {
+  /** The ADMIN_PATH segment used to build redirect URLs after login. */
+  adminPath: string;
+}
+
+export function AdminLoginForm({ adminPath }: AdminLoginFormProps) {
+  const router = useRouter();
+  const [email, setEmail] = useState("");
+  const [otp, setOtp] = useState("");
+  const [step, setStep] = useState<"email" | "otp">("email");
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState("");
+  const [successMessage, setSuccessMessage] = useState("");
+  const [resendCooldown, setResendCooldown] = useState(0);
+
+  const dashboardUrl = adminPath ? `/${adminPath}/dashboard` : "/portal/dashboard";
+
+  useEffect(() => {
+    if (resendCooldown > 0) {
+      const timer = setTimeout(() => setResendCooldown((prev) => prev - 1), 1000);
+      return () => clearTimeout(timer);
+    }
+  }, [resendCooldown]);
+
+  const validateEmail = (value: string): boolean => {
+    if (!value) {
+      setError("Email is required");
+      return false;
+    }
+    if (value.length > 320) {
+      setError("Email exceeds maximum length");
+      return false;
+    }
+    if (!EMAIL_REGEX.test(value)) {
+      setError("Invalid email format");
+      return false;
+    }
+    return true;
+  };
+
+  const handleSendOtp = async () => {
+    setError("");
+    setSuccessMessage("");
+
+    const normalizedEmail = email.trim().toLowerCase();
+    if (!validateEmail(normalizedEmail)) return;
+
+    setIsLoading(true);
+    try {
+      const response = await fetch("/api/admin/otp/generate", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ email: normalizedEmail }),
+      });
+
+      const data = await response.json();
+
+      if (response.ok) {
+        setSuccessMessage(data.message || "If this email is valid, an OTP has been sent.");
+        setStep("otp");
+        setResendCooldown(60);
+      } else {
+        setError(data.error || "Failed to send OTP");
+      }
+    } catch {
+      setError("Network error. Please try again.");
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  const handleVerifyOtp = async () => {
+    setError("");
+    setSuccessMessage("");
+
+    if (!otp) {
+      setError("OTP code is required");
+      return;
+    }
+
+    const otpNumber = parseInt(otp, 10);
+    if (isNaN(otpNumber) || otp.length !== 6) {
+      setError("Please enter a valid 6-digit OTP code");
+      return;
+    }
+
+    setIsLoading(true);
+    try {
+      const response = await fetch("/api/admin/otp/verify", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ email: email.trim().toLowerCase(), code: otpNumber }),
+      });
+
+      const data = await response.json();
+
+      if (response.ok && data.success) {
+        setSuccessMessage("Login successful! Redirecting...");
+        setTimeout(() => router.push(dashboardUrl), 1000);
+      } else {
+        setError(data.error || "Invalid or expired OTP");
+      }
+    } catch {
+      setError("Network error. Please try again.");
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  const handleKeyDown = (e: React.KeyboardEvent, action: () => void) => {
+    if (e.key === "Enter") action();
+  };
+
+  return (
+    <main className="flex min-h-screen items-center justify-center bg-background px-4">
+      <Card className="w-full max-w-md">
+        <CardHeader>
+          <CardTitle>Admin Portal</CardTitle>
+          <CardDescription>
+            {step === "email"
+              ? "Enter your admin email to receive a login code"
+              : "Enter the 6-digit code sent to your email"}
+          </CardDescription>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          {step === "email" ? (
+            <>
+              <div className="space-y-2">
+                <Label htmlFor="email">Email Address</Label>
+                <Input
+                  id="email"
+                  type="email"
+                  placeholder="admin@example.com"
+                  value={email}
+                  onChange={(e) => setEmail(e.target.value)}
+                  onKeyDown={(e) => handleKeyDown(e, handleSendOtp)}
+                  disabled={isLoading}
+                  aria-required="true"
+                  aria-invalid={!!error}
+                  aria-describedby={error ? "email-error" : undefined}
+                />
+              </div>
+              <Button onClick={handleSendOtp} disabled={isLoading} className="w-full">
+                {isLoading ? "Sending..." : "Send Code"}
+              </Button>
+            </>
+          ) : (
+            <>
+              <div className="space-y-2">
+                <Label htmlFor="otp">Verification Code</Label>
+                <Input
+                  id="otp"
+                  type="text"
+                  inputMode="numeric"
+                  pattern="[0-9]*"
+                  maxLength={6}
+                  placeholder="000000"
+                  value={otp}
+                  onChange={(e) => setOtp(e.target.value.replace(/\D/g, ""))}
+                  onKeyDown={(e) => handleKeyDown(e, handleVerifyOtp)}
+                  disabled={isLoading}
+                  aria-required="true"
+                  aria-invalid={!!error}
+                  aria-describedby={error ? "otp-error" : undefined}
+                  autoComplete="one-time-code"
+                />
+              </div>
+              <Button onClick={handleVerifyOtp} disabled={isLoading} className="w-full">
+                {isLoading ? "Verifying..." : "Verify & Login"}
+              </Button>
+              <div className="flex flex-col sm:flex-row gap-2 items-center justify-between text-sm">
+                <Button
+                  variant="ghost"
+                  onClick={() => {
+                    setStep("email");
+                    setOtp("");
+                    setError("");
+                    setSuccessMessage("");
+                  }}
+                  disabled={isLoading}
+                  className="text-muted-foreground"
+                >
+                  Change Email
+                </Button>
+                <Button
+                  variant="ghost"
+                  onClick={() => { setOtp(""); handleSendOtp(); }}
+                  disabled={isLoading || resendCooldown > 0}
+                  className="text-muted-foreground"
+                  aria-label={
+                    resendCooldown > 0
+                      ? `Resend available in ${resendCooldown} seconds`
+                      : "Resend OTP"
+                  }
+                >
+                  {resendCooldown > 0 ? `Resend (${resendCooldown}s)` : "Resend Code"}
+                </Button>
+              </div>
+            </>
+          )}
+
+          {error && (
+            <div
+              id={step === "email" ? "email-error" : "otp-error"}
+              className="text-sm text-destructive"
+              role="alert"
+              aria-live="polite"
+            >
+              {error}
+            </div>
+          )}
+
+          {successMessage && (
+            <div className="text-sm text-primary" role="status" aria-live="polite">
+              {successMessage}
+            </div>
+          )}
+        </CardContent>
+      </Card>
+    </main>
+  );
+}

--- a/src/controllers/AdminAuthController.ts
+++ b/src/controllers/AdminAuthController.ts
@@ -12,7 +12,7 @@ export class AdminAuthController {
   @Security("admin_cookie_auth")
   @SuccessResponse("200", "Session retrieved")
   @Response<{ error: string }>("401", "Unauthorized")
-  public async getSession(@Request() req: ExpressRequest): Promise<AdminSessionResponseDto> {
+  public async getAdminSession(@Request() req: ExpressRequest): Promise<AdminSessionResponseDto> {
     return {
       authenticated: true,
       adminUser: req.adminUser!,
@@ -28,7 +28,7 @@ export class AdminAuthController {
   @Post("logout")
   @SuccessResponse("200", "Logged out")
   @Response<{ error: string }>("500", "Server error")
-  public async logout(@Request() req: ExpressRequest): Promise<{ success: boolean }> {
+  public async logoutAdmin(@Request() req: ExpressRequest): Promise<{ success: boolean }> {
     const sessionToken = req.cookies?.admin_session_token;
 
     try {

--- a/src/controllers/AdminAuthController.ts
+++ b/src/controllers/AdminAuthController.ts
@@ -1,0 +1,44 @@
+import { Get, Post, Route, Response, Security, SuccessResponse, Request } from "tsoa";
+import { AdminSessionResponseDto } from "../dto/AdminOtpDto";
+import * as adminRepo from "../repo/adminRepo";
+import type { Request as ExpressRequest } from "express";
+
+@Route("admin/auth")
+export class AdminAuthController {
+  /**
+   * Get current admin session information
+   */
+  @Get("session")
+  @Security("admin_cookie_auth")
+  @SuccessResponse("200", "Session retrieved")
+  @Response<{ error: string }>("401", "Unauthorized")
+  public async getSession(@Request() req: ExpressRequest): Promise<AdminSessionResponseDto> {
+    return {
+      authenticated: true,
+      adminUser: req.adminUser!,
+      session: {
+        expiresAt: req.adminSession!.expiresAt,
+      },
+    };
+  }
+
+  /**
+   * Logout admin session
+   */
+  @Post("logout")
+  @SuccessResponse("200", "Logged out")
+  @Response<{ error: string }>("500", "Server error")
+  public async logout(@Request() req: ExpressRequest): Promise<{ success: boolean }> {
+    const sessionToken = req.cookies?.admin_session_token;
+
+    try {
+      if (sessionToken) {
+        await adminRepo.deleteAdminSessionByToken(sessionToken);
+      }
+      return { success: true };
+    } catch (error: unknown) {
+      req.logger.error({ err: error, msg: "Failed to logout admin session" });
+      throw { status: 500, message: "Failed to logout" };
+    }
+  }
+}

--- a/src/controllers/AdminOtpController.ts
+++ b/src/controllers/AdminOtpController.ts
@@ -1,0 +1,103 @@
+import { Body, Post, Route, Response, SuccessResponse, Request } from "tsoa";
+import {
+  AdminRequestOtpDto,
+  AdminVerifyOtpDto,
+  AdminOtpResponseDto,
+  AdminVerifyOtpSuccessDto,
+} from "../dto/AdminOtpDto";
+import { adminOtpService } from "../services/adminOtpService";
+import { EMAIL_REGEX } from "../lib/utils";
+import type { Request as ExpressRequest } from "express";
+
+const GENERIC_MESSAGE = "If this email is valid, an OTP has been sent.";
+
+@Route("admin/otp")
+export class AdminOtpController {
+  /**
+   * Request an admin OTP code
+   */
+  @Post("generate")
+  @SuccessResponse("200", "OTP sent")
+  @Response<{ error: string }>("400", "Validation error")
+  @Response<{ message: string; details: Record<string, unknown> }>("422", "DTO validation failed")
+  @Response<{ error: string; message: string }>("429", "Rate limit exceeded")
+  @Response<{ error: string; message: string }>("500", "Server error")
+  public async requestOtp(
+    @Body() body: AdminRequestOtpDto,
+    @Request() req: ExpressRequest,
+  ): Promise<AdminOtpResponseDto> {
+    try {
+      const { email } = body;
+      const normalizedEmail = email.trim().toLowerCase();
+
+      if (!EMAIL_REGEX.test(normalizedEmail)) {
+        throw { status: 400, message: "Invalid email format" };
+      }
+
+      const result = await adminOtpService.requestOtp(normalizedEmail, req.logger);
+
+      if (!result.success) {
+        const statusCode = result.statusCode || 500;
+        throw {
+          status: statusCode,
+          message: result.error || "An error occurred",
+          retryAfter: result.retryAfter,
+          genericMessage: GENERIC_MESSAGE,
+        };
+      }
+
+      req.logger.info({ msg: "Admin OTP request processed", email: normalizedEmail });
+      return { message: GENERIC_MESSAGE };
+    } catch (error: unknown) {
+      if (isControllerError(error)) throw error;
+      req.logger.error({ err: error, msg: "Unexpected error in admin OTP request" });
+      throw { status: 500, message: "Internal server error", genericMessage: GENERIC_MESSAGE };
+    }
+  }
+
+  /**
+   * Verify an admin OTP code and create an admin session
+   */
+  @Post("verify")
+  @SuccessResponse("200", "OTP verified")
+  @Response<{ error: string }>("400", "Validation error")
+  @Response<{ error: string }>("401", "Invalid OTP or not an admin")
+  @Response<{ message: string; details: Record<string, unknown> }>("422", "DTO validation failed")
+  @Response<{ error: string }>("500", "Server error")
+  public async verifyOtp(
+    @Body() body: AdminVerifyOtpDto,
+    @Request() req: ExpressRequest,
+  ): Promise<AdminVerifyOtpSuccessDto> {
+    const { email, code } = body;
+    const normalizedEmail = email.trim().toLowerCase();
+
+    if (!EMAIL_REGEX.test(normalizedEmail)) {
+      throw { status: 400, message: "Invalid email format" };
+    }
+
+    const result = await adminOtpService.verifyOtp(normalizedEmail, code, req.logger);
+
+    if (!result.success) {
+      throw { status: result.statusCode || 500, message: result.error || "Verification failed" };
+    }
+
+    req.logger.info({ msg: "Admin OTP verified successfully", email: normalizedEmail });
+    return {
+      message: "OTP verified successfully",
+      success: true,
+      sessionToken: result.sessionToken!,
+      adminUser: result.adminUser!,
+    };
+  }
+}
+
+function isControllerError(err: unknown): err is { status: number; message: string } {
+  return (
+    typeof err === "object" &&
+    err !== null &&
+    "status" in err &&
+    typeof (err as Record<string, unknown>).status === "number" &&
+    "message" in err &&
+    typeof (err as Record<string, unknown>).message === "string"
+  );
+}

--- a/src/controllers/AdminOtpController.ts
+++ b/src/controllers/AdminOtpController.ts
@@ -22,7 +22,7 @@ export class AdminOtpController {
   @Response<{ message: string; details: Record<string, unknown> }>("422", "DTO validation failed")
   @Response<{ error: string; message: string }>("429", "Rate limit exceeded")
   @Response<{ error: string; message: string }>("500", "Server error")
-  public async requestOtp(
+  public async requestAdminOtp(
     @Body() body: AdminRequestOtpDto,
     @Request() req: ExpressRequest,
   ): Promise<AdminOtpResponseDto> {
@@ -64,7 +64,7 @@ export class AdminOtpController {
   @Response<{ error: string }>("401", "Invalid OTP or not an admin")
   @Response<{ message: string; details: Record<string, unknown> }>("422", "DTO validation failed")
   @Response<{ error: string }>("500", "Server error")
-  public async verifyOtp(
+  public async verifyAdminOtp(
     @Body() body: AdminVerifyOtpDto,
     @Request() req: ExpressRequest,
   ): Promise<AdminVerifyOtpSuccessDto> {

--- a/src/dto/AdminOtpDto.ts
+++ b/src/dto/AdminOtpDto.ts
@@ -1,0 +1,55 @@
+export class AdminRequestOtpDto {
+  /**
+   * Admin email address
+   * @example "admin@example.com"
+   * @format email
+   * @maxLength 320
+   */
+  email!: string;
+}
+
+export class AdminVerifyOtpDto {
+  /**
+   * Admin email address
+   * @example "admin@example.com"
+   * @format email
+   * @maxLength 320
+   */
+  email!: string;
+
+  /**
+   * 6-digit OTP code
+   * @example 123456
+   * @isInt
+   * @minimum 100000
+   * @maximum 999999
+   */
+  code!: number;
+}
+
+export class AdminOtpResponseDto {
+  message!: string;
+}
+
+export class AdminVerifyOtpSuccessDto {
+  message!: string;
+  success!: boolean;
+  sessionToken!: string;
+  adminUser!: {
+    id: string;
+    email: string;
+    name: string | null;
+  };
+}
+
+export class AdminSessionResponseDto {
+  authenticated!: boolean;
+  adminUser!: {
+    id: string;
+    email: string;
+    name: string | null;
+  };
+  session!: {
+    expiresAt: Date;
+  };
+}

--- a/src/generated/routes.ts
+++ b/src/generated/routes.ts
@@ -11,6 +11,10 @@ import { OtpController } from './../controllers/OtpController';
 import { OnboardingController } from './../controllers/OnboardingController';
 // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
 import { AuthController } from './../controllers/AuthController';
+// WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+import { AdminOtpController } from './../controllers/AdminOtpController';
+// WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+import { AdminAuthController } from './../controllers/AdminAuthController';
 import { expressAuthentication } from './../middleware/tsoaAuthentication';
 // @ts-ignore - no great way to install types from subpackage
 import type { Request as ExRequest, Response as ExResponse, RequestHandler, Router } from 'express';
@@ -149,6 +153,52 @@ const models: TsoaRoute.Models = {
             "employmentStatus": {"dataType":"union","subSchemas":[{"ref":"EmploymentStatus"},{"dataType":"enum","enums":[null]}]},
             "arrivalDate": {"dataType":"union","subSchemas":[{"dataType":"string"},{"dataType":"enum","enums":[null]}]},
             "plannedArrivalDate": {"dataType":"union","subSchemas":[{"dataType":"string"},{"dataType":"enum","enums":[null]}]},
+        },
+        "additionalProperties": false,
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    "AdminOtpResponseDto": {
+        "dataType": "refObject",
+        "properties": {
+            "message": {"dataType":"string","required":true},
+        },
+        "additionalProperties": false,
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    "AdminRequestOtpDto": {
+        "dataType": "refObject",
+        "properties": {
+            "email": {"dataType":"string","required":true,"validators":{"maxLength":{"value":320}}},
+        },
+        "additionalProperties": false,
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    "AdminVerifyOtpSuccessDto": {
+        "dataType": "refObject",
+        "properties": {
+            "message": {"dataType":"string","required":true},
+            "success": {"dataType":"boolean","required":true},
+            "sessionToken": {"dataType":"string","required":true},
+            "adminUser": {"dataType":"nestedObjectLiteral","nestedProperties":{"name":{"dataType":"union","subSchemas":[{"dataType":"string"},{"dataType":"enum","enums":[null]}],"required":true},"email":{"dataType":"string","required":true},"id":{"dataType":"string","required":true}},"required":true},
+        },
+        "additionalProperties": false,
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    "AdminVerifyOtpDto": {
+        "dataType": "refObject",
+        "properties": {
+            "email": {"dataType":"string","required":true,"validators":{"maxLength":{"value":320}}},
+            "code": {"dataType":"integer","required":true,"validators":{"minimum":{"value":100000},"maximum":{"value":999999}}},
+        },
+        "additionalProperties": false,
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    "AdminSessionResponseDto": {
+        "dataType": "refObject",
+        "properties": {
+            "authenticated": {"dataType":"boolean","required":true},
+            "adminUser": {"dataType":"nestedObjectLiteral","nestedProperties":{"name":{"dataType":"union","subSchemas":[{"dataType":"string"},{"dataType":"enum","enums":[null]}],"required":true},"email":{"dataType":"string","required":true},"id":{"dataType":"string","required":true}},"required":true},
+            "session": {"dataType":"nestedObjectLiteral","nestedProperties":{"expiresAt":{"dataType":"datetime","required":true}},"required":true},
         },
         "additionalProperties": false,
     },
@@ -535,6 +585,129 @@ export function RegisterRoutes(app: Router) {
 
               await templateService.apiHandler({
                 methodName: 'deleteProfile',
+                controller,
+                response,
+                next,
+                validatedArgs,
+                successStatus: 200,
+              });
+            } catch (err) {
+                return next(err);
+            }
+        });
+        // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+        const argsAdminOtpController_requestOtp: Record<string, TsoaRoute.ParameterSchema> = {
+                body: {"in":"body","name":"body","required":true,"ref":"AdminRequestOtpDto"},
+                req: {"in":"request","name":"req","required":true,"dataType":"object"},
+        };
+        app.post('/api/admin/otp/generate',
+            ...(fetchMiddlewares<RequestHandler>(AdminOtpController)),
+            ...(fetchMiddlewares<RequestHandler>(AdminOtpController.prototype.requestOtp)),
+
+            async function AdminOtpController_requestOtp(request: ExRequest, response: ExResponse, next: any) {
+
+            // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+
+            let validatedArgs: any[] = [];
+            try {
+                validatedArgs = templateService.getValidatedArgs({ args: argsAdminOtpController_requestOtp, request, response });
+
+                const controller = new AdminOtpController();
+
+              await templateService.apiHandler({
+                methodName: 'requestOtp',
+                controller,
+                response,
+                next,
+                validatedArgs,
+                successStatus: 200,
+              });
+            } catch (err) {
+                return next(err);
+            }
+        });
+        // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+        const argsAdminOtpController_verifyOtp: Record<string, TsoaRoute.ParameterSchema> = {
+                body: {"in":"body","name":"body","required":true,"ref":"AdminVerifyOtpDto"},
+                req: {"in":"request","name":"req","required":true,"dataType":"object"},
+        };
+        app.post('/api/admin/otp/verify',
+            ...(fetchMiddlewares<RequestHandler>(AdminOtpController)),
+            ...(fetchMiddlewares<RequestHandler>(AdminOtpController.prototype.verifyOtp)),
+
+            async function AdminOtpController_verifyOtp(request: ExRequest, response: ExResponse, next: any) {
+
+            // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+
+            let validatedArgs: any[] = [];
+            try {
+                validatedArgs = templateService.getValidatedArgs({ args: argsAdminOtpController_verifyOtp, request, response });
+
+                const controller = new AdminOtpController();
+
+              await templateService.apiHandler({
+                methodName: 'verifyOtp',
+                controller,
+                response,
+                next,
+                validatedArgs,
+                successStatus: 200,
+              });
+            } catch (err) {
+                return next(err);
+            }
+        });
+        // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+        const argsAdminAuthController_getSession: Record<string, TsoaRoute.ParameterSchema> = {
+                req: {"in":"request","name":"req","required":true,"dataType":"object"},
+        };
+        app.get('/api/admin/auth/session',
+            authenticateMiddleware([{"admin_cookie_auth":[]}]),
+            ...(fetchMiddlewares<RequestHandler>(AdminAuthController)),
+            ...(fetchMiddlewares<RequestHandler>(AdminAuthController.prototype.getSession)),
+
+            async function AdminAuthController_getSession(request: ExRequest, response: ExResponse, next: any) {
+
+            // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+
+            let validatedArgs: any[] = [];
+            try {
+                validatedArgs = templateService.getValidatedArgs({ args: argsAdminAuthController_getSession, request, response });
+
+                const controller = new AdminAuthController();
+
+              await templateService.apiHandler({
+                methodName: 'getSession',
+                controller,
+                response,
+                next,
+                validatedArgs,
+                successStatus: 200,
+              });
+            } catch (err) {
+                return next(err);
+            }
+        });
+        // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+        const argsAdminAuthController_logout: Record<string, TsoaRoute.ParameterSchema> = {
+                req: {"in":"request","name":"req","required":true,"dataType":"object"},
+        };
+        app.post('/api/admin/auth/logout',
+            ...(fetchMiddlewares<RequestHandler>(AdminAuthController)),
+            ...(fetchMiddlewares<RequestHandler>(AdminAuthController.prototype.logout)),
+
+            async function AdminAuthController_logout(request: ExRequest, response: ExResponse, next: any) {
+
+            // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+
+            let validatedArgs: any[] = [];
+            try {
+                validatedArgs = templateService.getValidatedArgs({ args: argsAdminAuthController_logout, request, response });
+
+                const controller = new AdminAuthController();
+
+              await templateService.apiHandler({
+                methodName: 'logout',
                 controller,
                 response,
                 next,

--- a/src/generated/routes.ts
+++ b/src/generated/routes.ts
@@ -596,26 +596,26 @@ export function RegisterRoutes(app: Router) {
             }
         });
         // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-        const argsAdminOtpController_requestOtp: Record<string, TsoaRoute.ParameterSchema> = {
+        const argsAdminOtpController_requestAdminOtp: Record<string, TsoaRoute.ParameterSchema> = {
                 body: {"in":"body","name":"body","required":true,"ref":"AdminRequestOtpDto"},
                 req: {"in":"request","name":"req","required":true,"dataType":"object"},
         };
         app.post('/api/admin/otp/generate',
             ...(fetchMiddlewares<RequestHandler>(AdminOtpController)),
-            ...(fetchMiddlewares<RequestHandler>(AdminOtpController.prototype.requestOtp)),
+            ...(fetchMiddlewares<RequestHandler>(AdminOtpController.prototype.requestAdminOtp)),
 
-            async function AdminOtpController_requestOtp(request: ExRequest, response: ExResponse, next: any) {
+            async function AdminOtpController_requestAdminOtp(request: ExRequest, response: ExResponse, next: any) {
 
             // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
 
             let validatedArgs: any[] = [];
             try {
-                validatedArgs = templateService.getValidatedArgs({ args: argsAdminOtpController_requestOtp, request, response });
+                validatedArgs = templateService.getValidatedArgs({ args: argsAdminOtpController_requestAdminOtp, request, response });
 
                 const controller = new AdminOtpController();
 
               await templateService.apiHandler({
-                methodName: 'requestOtp',
+                methodName: 'requestAdminOtp',
                 controller,
                 response,
                 next,
@@ -627,26 +627,26 @@ export function RegisterRoutes(app: Router) {
             }
         });
         // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-        const argsAdminOtpController_verifyOtp: Record<string, TsoaRoute.ParameterSchema> = {
+        const argsAdminOtpController_verifyAdminOtp: Record<string, TsoaRoute.ParameterSchema> = {
                 body: {"in":"body","name":"body","required":true,"ref":"AdminVerifyOtpDto"},
                 req: {"in":"request","name":"req","required":true,"dataType":"object"},
         };
         app.post('/api/admin/otp/verify',
             ...(fetchMiddlewares<RequestHandler>(AdminOtpController)),
-            ...(fetchMiddlewares<RequestHandler>(AdminOtpController.prototype.verifyOtp)),
+            ...(fetchMiddlewares<RequestHandler>(AdminOtpController.prototype.verifyAdminOtp)),
 
-            async function AdminOtpController_verifyOtp(request: ExRequest, response: ExResponse, next: any) {
+            async function AdminOtpController_verifyAdminOtp(request: ExRequest, response: ExResponse, next: any) {
 
             // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
 
             let validatedArgs: any[] = [];
             try {
-                validatedArgs = templateService.getValidatedArgs({ args: argsAdminOtpController_verifyOtp, request, response });
+                validatedArgs = templateService.getValidatedArgs({ args: argsAdminOtpController_verifyAdminOtp, request, response });
 
                 const controller = new AdminOtpController();
 
               await templateService.apiHandler({
-                methodName: 'verifyOtp',
+                methodName: 'verifyAdminOtp',
                 controller,
                 response,
                 next,
@@ -658,26 +658,26 @@ export function RegisterRoutes(app: Router) {
             }
         });
         // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-        const argsAdminAuthController_getSession: Record<string, TsoaRoute.ParameterSchema> = {
+        const argsAdminAuthController_getAdminSession: Record<string, TsoaRoute.ParameterSchema> = {
                 req: {"in":"request","name":"req","required":true,"dataType":"object"},
         };
         app.get('/api/admin/auth/session',
             authenticateMiddleware([{"admin_cookie_auth":[]}]),
             ...(fetchMiddlewares<RequestHandler>(AdminAuthController)),
-            ...(fetchMiddlewares<RequestHandler>(AdminAuthController.prototype.getSession)),
+            ...(fetchMiddlewares<RequestHandler>(AdminAuthController.prototype.getAdminSession)),
 
-            async function AdminAuthController_getSession(request: ExRequest, response: ExResponse, next: any) {
+            async function AdminAuthController_getAdminSession(request: ExRequest, response: ExResponse, next: any) {
 
             // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
 
             let validatedArgs: any[] = [];
             try {
-                validatedArgs = templateService.getValidatedArgs({ args: argsAdminAuthController_getSession, request, response });
+                validatedArgs = templateService.getValidatedArgs({ args: argsAdminAuthController_getAdminSession, request, response });
 
                 const controller = new AdminAuthController();
 
               await templateService.apiHandler({
-                methodName: 'getSession',
+                methodName: 'getAdminSession',
                 controller,
                 response,
                 next,
@@ -689,25 +689,25 @@ export function RegisterRoutes(app: Router) {
             }
         });
         // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-        const argsAdminAuthController_logout: Record<string, TsoaRoute.ParameterSchema> = {
+        const argsAdminAuthController_logoutAdmin: Record<string, TsoaRoute.ParameterSchema> = {
                 req: {"in":"request","name":"req","required":true,"dataType":"object"},
         };
         app.post('/api/admin/auth/logout',
             ...(fetchMiddlewares<RequestHandler>(AdminAuthController)),
-            ...(fetchMiddlewares<RequestHandler>(AdminAuthController.prototype.logout)),
+            ...(fetchMiddlewares<RequestHandler>(AdminAuthController.prototype.logoutAdmin)),
 
-            async function AdminAuthController_logout(request: ExRequest, response: ExResponse, next: any) {
+            async function AdminAuthController_logoutAdmin(request: ExRequest, response: ExResponse, next: any) {
 
             // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
 
             let validatedArgs: any[] = [];
             try {
-                validatedArgs = templateService.getValidatedArgs({ args: argsAdminAuthController_logout, request, response });
+                validatedArgs = templateService.getValidatedArgs({ args: argsAdminAuthController_logoutAdmin, request, response });
 
                 const controller = new AdminAuthController();
 
               await templateService.apiHandler({
-                methodName: 'logout',
+                methodName: 'logoutAdmin',
                 controller,
                 response,
                 next,

--- a/src/generated/swagger.json
+++ b/src/generated/swagger.json
@@ -1583,7 +1583,7 @@
 		},
 		"/admin/otp/generate": {
 			"post": {
-				"operationId": "RequestOtp",
+				"operationId": "RequestAdminOtp",
 				"responses": {
 					"200": {
 						"description": "OTP sent",
@@ -1697,7 +1697,7 @@
 		},
 		"/admin/otp/verify": {
 			"post": {
-				"operationId": "VerifyOtp",
+				"operationId": "VerifyAdminOtp",
 				"responses": {
 					"200": {
 						"description": "OTP verified",
@@ -1803,7 +1803,7 @@
 		},
 		"/admin/auth/session": {
 			"get": {
-				"operationId": "GetSession",
+				"operationId": "GetAdminSession",
 				"responses": {
 					"200": {
 						"description": "Session retrieved",
@@ -1845,7 +1845,7 @@
 		},
 		"/admin/auth/logout": {
 			"post": {
-				"operationId": "Logout",
+				"operationId": "LogoutAdmin",
 				"responses": {
 					"200": {
 						"description": "Logged out",

--- a/src/generated/swagger.json
+++ b/src/generated/swagger.json
@@ -423,6 +423,146 @@
 				},
 				"type": "object",
 				"additionalProperties": false
+			},
+			"AdminOtpResponseDto": {
+				"properties": {
+					"message": {
+						"type": "string"
+					}
+				},
+				"required": [
+					"message"
+				],
+				"type": "object",
+				"additionalProperties": false
+			},
+			"AdminRequestOtpDto": {
+				"properties": {
+					"email": {
+						"type": "string",
+						"description": "Admin email address",
+						"example": "admin@example.com",
+						"format": "email",
+						"maxLength": 320
+					}
+				},
+				"required": [
+					"email"
+				],
+				"type": "object",
+				"additionalProperties": false
+			},
+			"AdminVerifyOtpSuccessDto": {
+				"properties": {
+					"message": {
+						"type": "string"
+					},
+					"success": {
+						"type": "boolean"
+					},
+					"sessionToken": {
+						"type": "string"
+					},
+					"adminUser": {
+						"properties": {
+							"name": {
+								"type": "string",
+								"nullable": true
+							},
+							"email": {
+								"type": "string"
+							},
+							"id": {
+								"type": "string"
+							}
+						},
+						"required": [
+							"name",
+							"email",
+							"id"
+						],
+						"type": "object"
+					}
+				},
+				"required": [
+					"message",
+					"success",
+					"sessionToken",
+					"adminUser"
+				],
+				"type": "object",
+				"additionalProperties": false
+			},
+			"AdminVerifyOtpDto": {
+				"properties": {
+					"email": {
+						"type": "string",
+						"description": "Admin email address",
+						"example": "admin@example.com",
+						"format": "email",
+						"maxLength": 320
+					},
+					"code": {
+						"type": "integer",
+						"format": "int32",
+						"description": "6-digit OTP code",
+						"example": 123456,
+						"minimum": 100000,
+						"maximum": 999999
+					}
+				},
+				"required": [
+					"email",
+					"code"
+				],
+				"type": "object",
+				"additionalProperties": false
+			},
+			"AdminSessionResponseDto": {
+				"properties": {
+					"authenticated": {
+						"type": "boolean"
+					},
+					"adminUser": {
+						"properties": {
+							"name": {
+								"type": "string",
+								"nullable": true
+							},
+							"email": {
+								"type": "string"
+							},
+							"id": {
+								"type": "string"
+							}
+						},
+						"required": [
+							"name",
+							"email",
+							"id"
+						],
+						"type": "object"
+					},
+					"session": {
+						"properties": {
+							"expiresAt": {
+								"type": "string",
+								"format": "date-time"
+							}
+						},
+						"required": [
+							"expiresAt"
+						],
+						"type": "object"
+					}
+				},
+				"required": [
+					"authenticated",
+					"adminUser",
+					"session"
+				],
+				"type": "object",
+				"additionalProperties": false
 			}
 		},
 		"securitySchemes": {
@@ -431,6 +571,12 @@
 				"in": "cookie",
 				"name": "session_token",
 				"description": "Session token cookie obtained from /api/otp/verify"
+			},
+			"admin_cookie_auth": {
+				"type": "apiKey",
+				"in": "cookie",
+				"name": "admin_session_token",
+				"description": "Admin session token cookie obtained from /api/admin/otp/verify"
 			}
 		}
 	},
@@ -1431,6 +1577,314 @@
 					}
 				},
 				"description": "Logout user session",
+				"security": [],
+				"parameters": []
+			}
+		},
+		"/admin/otp/generate": {
+			"post": {
+				"operationId": "RequestOtp",
+				"responses": {
+					"200": {
+						"description": "OTP sent",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/AdminOtpResponseDto"
+								}
+							}
+						}
+					},
+					"400": {
+						"description": "Validation error",
+						"content": {
+							"application/json": {
+								"schema": {
+									"properties": {
+										"error": {
+											"type": "string"
+										}
+									},
+									"required": [
+										"error"
+									],
+									"type": "object"
+								}
+							}
+						}
+					},
+					"422": {
+						"description": "DTO validation failed",
+						"content": {
+							"application/json": {
+								"schema": {
+									"properties": {
+										"details": {
+											"$ref": "#/components/schemas/Record_string.unknown_"
+										},
+										"message": {
+											"type": "string"
+										}
+									},
+									"required": [
+										"details",
+										"message"
+									],
+									"type": "object"
+								}
+							}
+						}
+					},
+					"429": {
+						"description": "Rate limit exceeded",
+						"content": {
+							"application/json": {
+								"schema": {
+									"properties": {
+										"message": {
+											"type": "string"
+										},
+										"error": {
+											"type": "string"
+										}
+									},
+									"required": [
+										"message",
+										"error"
+									],
+									"type": "object"
+								}
+							}
+						}
+					},
+					"500": {
+						"description": "Server error",
+						"content": {
+							"application/json": {
+								"schema": {
+									"properties": {
+										"message": {
+											"type": "string"
+										},
+										"error": {
+											"type": "string"
+										}
+									},
+									"required": [
+										"message",
+										"error"
+									],
+									"type": "object"
+								}
+							}
+						}
+					}
+				},
+				"description": "Request an admin OTP code",
+				"security": [],
+				"parameters": [],
+				"requestBody": {
+					"required": true,
+					"content": {
+						"application/json": {
+							"schema": {
+								"$ref": "#/components/schemas/AdminRequestOtpDto"
+							}
+						}
+					}
+				}
+			}
+		},
+		"/admin/otp/verify": {
+			"post": {
+				"operationId": "VerifyOtp",
+				"responses": {
+					"200": {
+						"description": "OTP verified",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/AdminVerifyOtpSuccessDto"
+								}
+							}
+						}
+					},
+					"400": {
+						"description": "Validation error",
+						"content": {
+							"application/json": {
+								"schema": {
+									"properties": {
+										"error": {
+											"type": "string"
+										}
+									},
+									"required": [
+										"error"
+									],
+									"type": "object"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Invalid OTP or not an admin",
+						"content": {
+							"application/json": {
+								"schema": {
+									"properties": {
+										"error": {
+											"type": "string"
+										}
+									},
+									"required": [
+										"error"
+									],
+									"type": "object"
+								}
+							}
+						}
+					},
+					"422": {
+						"description": "DTO validation failed",
+						"content": {
+							"application/json": {
+								"schema": {
+									"properties": {
+										"details": {
+											"$ref": "#/components/schemas/Record_string.unknown_"
+										},
+										"message": {
+											"type": "string"
+										}
+									},
+									"required": [
+										"details",
+										"message"
+									],
+									"type": "object"
+								}
+							}
+						}
+					},
+					"500": {
+						"description": "Server error",
+						"content": {
+							"application/json": {
+								"schema": {
+									"properties": {
+										"error": {
+											"type": "string"
+										}
+									},
+									"required": [
+										"error"
+									],
+									"type": "object"
+								}
+							}
+						}
+					}
+				},
+				"description": "Verify an admin OTP code and create an admin session",
+				"security": [],
+				"parameters": [],
+				"requestBody": {
+					"required": true,
+					"content": {
+						"application/json": {
+							"schema": {
+								"$ref": "#/components/schemas/AdminVerifyOtpDto"
+							}
+						}
+					}
+				}
+			}
+		},
+		"/admin/auth/session": {
+			"get": {
+				"operationId": "GetSession",
+				"responses": {
+					"200": {
+						"description": "Session retrieved",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/AdminSessionResponseDto"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized",
+						"content": {
+							"application/json": {
+								"schema": {
+									"properties": {
+										"error": {
+											"type": "string"
+										}
+									},
+									"required": [
+										"error"
+									],
+									"type": "object"
+								}
+							}
+						}
+					}
+				},
+				"description": "Get current admin session information",
+				"security": [
+					{
+						"admin_cookie_auth": []
+					}
+				],
+				"parameters": []
+			}
+		},
+		"/admin/auth/logout": {
+			"post": {
+				"operationId": "Logout",
+				"responses": {
+					"200": {
+						"description": "Logged out",
+						"content": {
+							"application/json": {
+								"schema": {
+									"properties": {
+										"success": {
+											"type": "boolean"
+										}
+									},
+									"required": [
+										"success"
+									],
+									"type": "object"
+								}
+							}
+						}
+					},
+					"500": {
+						"description": "Server error",
+						"content": {
+							"application/json": {
+								"schema": {
+									"properties": {
+										"error": {
+											"type": "string"
+										}
+									},
+									"required": [
+										"error"
+									],
+									"type": "object"
+								}
+							}
+						}
+					}
+				},
+				"description": "Logout admin session",
 				"security": [],
 				"parameters": []
 			}

--- a/src/lib/adminSessionCookieSig.ts
+++ b/src/lib/adminSessionCookieSig.ts
@@ -1,0 +1,74 @@
+/**
+ * HMAC-signed session cookie helpers for the admin portal.
+ *
+ * Mirrors sessionCookieSig.ts but uses ADMIN_SESSION_COOKIE_SECRET and
+ * separate cookie names so admin and regular user sessions are fully isolated.
+ *
+ * Cookie names: "admin_session_token" + "admin_session_sig"
+ * HMAC input:   "{sessionToken}:{expiresAtSec}"
+ */
+
+export const ADMIN_SESSION_TOKEN_COOKIE_NAME = "admin_session_token";
+export const ADMIN_SESSION_SIG_COOKIE_NAME = "admin_session_sig";
+
+export function clearAdminSessionCookies(response: {
+  cookies: { set: (name: string, value: string, options: object) => void };
+}): void {
+  const expiredOptions = {
+    httpOnly: true,
+    secure: process.env.NODE_ENV === "production",
+    sameSite: "lax" as const,
+    path: "/",
+    maxAge: 0,
+  };
+  response.cookies.set(ADMIN_SESSION_TOKEN_COOKIE_NAME, "", expiredOptions);
+  response.cookies.set(ADMIN_SESSION_SIG_COOKIE_NAME, "", expiredOptions);
+}
+
+async function hmacSha256(secret: string, data: string): Promise<string> {
+  const enc = new TextEncoder();
+  const key = await crypto.subtle.importKey(
+    "raw",
+    enc.encode(secret),
+    { name: "HMAC", hash: "SHA-256" },
+    false,
+    ["sign"],
+  );
+  const sig = await crypto.subtle.sign("HMAC", key, enc.encode(data));
+  return Array.from(new Uint8Array(sig))
+    .map((b) => b.toString(16).padStart(2, "0"))
+    .join("");
+}
+
+export async function signAdminSessionCookie(
+  sessionToken: string,
+  expiresAt: Date,
+): Promise<string> {
+  const secret = process.env.ADMIN_SESSION_COOKIE_SECRET;
+  if (!secret) {
+    throw new Error("ADMIN_SESSION_COOKIE_SECRET environment variable is not set");
+  }
+  const expiresAtSec = Math.floor(expiresAt.getTime() / 1000);
+  const hmac = await hmacSha256(secret, `${sessionToken}:${expiresAtSec}`);
+  return `${expiresAtSec}.${hmac}`;
+}
+
+export async function verifyAdminSessionCookie(
+  sessionToken: string,
+  sessionSig: string,
+  secret: string,
+): Promise<boolean> {
+  const dotIdx = sessionSig.indexOf(".");
+  if (dotIdx === -1) return false;
+
+  const expStr = sessionSig.slice(0, dotIdx);
+  const providedHmac = sessionSig.slice(dotIdx + 1);
+
+  const expiresAtSec = parseInt(expStr, 10);
+  if (!Number.isFinite(expiresAtSec)) return false;
+
+  if (expiresAtSec <= Math.floor(Date.now() / 1000)) return false;
+
+  const expectedHmac = await hmacSha256(secret, `${sessionToken}:${expiresAtSec}`);
+  return expectedHmac === providedHmac;
+}

--- a/src/middleware/tsoaAuthentication.ts
+++ b/src/middleware/tsoaAuthentication.ts
@@ -1,7 +1,9 @@
 import { Request } from "express";
 import * as sessionRepo from "../repo/sessionRepo";
+import * as adminRepo from "../repo/adminRepo";
 
 const SESSION_COOKIE_NAME = "session_token";
+const ADMIN_SESSION_COOKIE_NAME = "admin_session_token";
 
 export async function expressAuthentication(
   request: Request,
@@ -36,6 +38,36 @@ export async function expressAuthentication(
     };
 
     return request.user;
+  }
+
+  if (securityName === "admin_cookie_auth") {
+    const sessionToken = request.cookies?.[ADMIN_SESSION_COOKIE_NAME];
+
+    if (!sessionToken) {
+      throw { status: 401, message: "Unauthorized" };
+    }
+
+    const session = await adminRepo.findAdminSessionWithUser(sessionToken);
+
+    if (!session || session.expiresAt <= new Date()) {
+      if (session) {
+        await adminRepo.deleteAdminSessionById(session.id);
+      }
+      throw { status: 401, message: "Unauthorized" };
+    }
+
+    request.adminUser = {
+      id: session.adminUser.id,
+      email: session.adminUser.email,
+      name: session.adminUser.name,
+    };
+    request.adminSession = {
+      id: session.id,
+      token: session.sessionToken,
+      expiresAt: session.expiresAt,
+    };
+
+    return request.adminUser as { id: string; email: string; name: string | null };
   }
 
   throw { status: 401, message: "Unknown security scheme" };

--- a/src/repo/adminRepo.ts
+++ b/src/repo/adminRepo.ts
@@ -1,0 +1,35 @@
+import { prisma, type DbClient } from "./db";
+
+type AdminDb = Pick<DbClient, "adminUser" | "adminSession">;
+
+// ── AdminUser ──────────────────────────────────────────────────────────────
+
+export const findAdminUserByEmail = (email: string, db: AdminDb = prisma) =>
+  db.adminUser.findUnique({ where: { email } });
+
+// ── AdminSession ───────────────────────────────────────────────────────────
+
+export const findAdminSessionWithUser = (sessionToken: string, db: AdminDb = prisma) =>
+  db.adminSession.findUnique({
+    where: { sessionToken },
+    include: { adminUser: true },
+  });
+
+export const createAdminSession = (
+  sessionToken: string,
+  adminUserId: string,
+  expiresAt: Date,
+  db: AdminDb = prisma,
+) =>
+  db.adminSession.create({
+    data: { sessionToken, adminUserId, expiresAt },
+  });
+
+export const deleteAdminSessionById = (id: string, db: AdminDb = prisma) =>
+  db.adminSession.delete({ where: { id } });
+
+export const deleteAdminSessionByToken = (sessionToken: string, db: AdminDb = prisma) =>
+  db.adminSession.deleteMany({ where: { sessionToken } });
+
+export const deleteAdminUserSessions = (adminUserId: string, db: AdminDb = prisma) =>
+  db.adminSession.deleteMany({ where: { adminUserId } });

--- a/src/repo/otpRepo.ts
+++ b/src/repo/otpRepo.ts
@@ -1,43 +1,55 @@
 import { prisma, type DbClient } from "./db";
 
 type OtpDb = Pick<DbClient, "oTPCode">;
+export type OtpPurpose = "USER" | "ADMIN";
 
-export const countRecentOtps = (email: string, windowStartTime: Date, db: OtpDb = prisma) =>
+export const countRecentOtps = (
+  email: string,
+  windowStartTime: Date,
+  purpose: OtpPurpose,
+  db: OtpDb = prisma,
+) =>
   db.oTPCode.count({
-    where: { email, createdAt: { gte: windowStartTime } },
+    where: { email, purpose, createdAt: { gte: windowStartTime } },
   });
 
-export const findOldestRecentOtp = (email: string, windowStartTime: Date, db: OtpDb = prisma) =>
+export const findOldestRecentOtp = (
+  email: string,
+  windowStartTime: Date,
+  purpose: OtpPurpose,
+  db: OtpDb = prisma,
+) =>
   db.oTPCode.findFirst({
-    where: { email, createdAt: { gte: windowStartTime } },
+    where: { email, purpose, createdAt: { gte: windowStartTime } },
     orderBy: { createdAt: "asc" },
   });
 
-export const deleteExpiredOtps = (email: string, db: OtpDb = prisma) =>
+export const deleteExpiredOtps = (email: string, purpose: OtpPurpose, db: OtpDb = prisma) =>
   db.oTPCode.deleteMany({
-    where: { email, expiresAt: { lt: new Date() } },
+    where: { email, purpose, expiresAt: { lt: new Date() } },
   });
 
 export const createOtp = (
   email: string,
   code: number,
   expiresAt: Date,
+  purpose: OtpPurpose,
   db: OtpDb = prisma,
 ) =>
   db.oTPCode.create({
-    data: { email, code, expiresAt },
+    data: { email, code, expiresAt, purpose },
   });
 
-export const findValidOtp = (email: string, code: number, db: OtpDb = prisma) =>
+export const findValidOtp = (email: string, code: number, purpose: OtpPurpose, db: OtpDb = prisma) =>
   db.oTPCode.findFirst({
-    where: { email, code, expiresAt: { gt: new Date() } },
+    where: { email, code, purpose, expiresAt: { gt: new Date() } },
   });
 
-export const deleteAllOtpsByEmail = (email: string, db: OtpDb = prisma) =>
-  db.oTPCode.deleteMany({ where: { email } });
+export const deleteAllOtpsByEmail = (email: string, purpose: OtpPurpose, db: OtpDb = prisma) =>
+  db.oTPCode.deleteMany({ where: { email, purpose } });
 
-export const findLatestValidOtp = (email: string, db: OtpDb = prisma) =>
+export const findLatestValidOtp = (email: string, purpose: OtpPurpose, db: OtpDb = prisma) =>
   db.oTPCode.findFirst({
-    where: { email, expiresAt: { gt: new Date() } },
+    where: { email, purpose, expiresAt: { gt: new Date() } },
     orderBy: { createdAt: "desc" },
   });

--- a/src/routes/otpRoutes.ts
+++ b/src/routes/otpRoutes.ts
@@ -14,7 +14,7 @@ if (process.env.NODE_ENV === "test") {
     if (!normalizedEmail) {
       return res.status(400).json({ error: "email query param required" });
     }
-    const otp = await findLatestValidOtp(normalizedEmail);
+    const otp = await findLatestValidOtp(normalizedEmail, "USER");
     if (!otp) {
       return res.status(404).json({ error: "No valid OTP found" });
     }

--- a/src/services/adminOtpService.ts
+++ b/src/services/adminOtpService.ts
@@ -64,17 +64,18 @@ export class AdminOtpService {
 
       await otpRepo.deleteExpiredOtps(email);
 
+      const code = randomInt(OTP_MIN_VALUE, OTP_MAX_VALUE + 1);
+      const expiresAt = new Date(Date.now() + OTP_EXPIRATION_MINUTES * 60 * 1000);
+      await otpRepo.createOtp(email, code, expiresAt);
+
       // Only send OTP to known admin emails — unknown emails receive a generic
-      // success response without an actual email being dispatched.
+      // success response without an actual email being dispatched. Recording
+      // the request for every address keeps rate-limit behavior uniform.
       const adminUser = await adminRepo.findAdminUserByEmail(email);
       if (!adminUser) {
         logger?.info({ msg: "Admin OTP requested for non-admin email (silently ignored)", email });
         return { success: true };
       }
-
-      const code = randomInt(OTP_MIN_VALUE, OTP_MAX_VALUE);
-      const expiresAt = new Date(Date.now() + OTP_EXPIRATION_MINUTES * 60 * 1000);
-      await otpRepo.createOtp(email, code, expiresAt);
 
       logger?.info({ msg: "Admin OTP generated", email, expiresIn: `${OTP_EXPIRATION_MINUTES}m` });
 
@@ -121,18 +122,19 @@ export class AdminOtpService {
       const result = await withTransaction(async (tx) => {
         await otpRepo.deleteAllOtpsByEmail(email, tx);
 
-        const adminUser = await adminRepo.findAdminUserByEmail(email);
+        const adminUser = await adminRepo.findAdminUserByEmail(email, tx);
         if (!adminUser) {
           throw { status: 401, message: "Unauthorized" };
         }
 
-        await adminRepo.deleteAdminUserSessions(adminUser.id);
+        await adminRepo.deleteAdminUserSessions(adminUser.id, tx);
 
         const sessionToken = randomBytes(SESSION_TOKEN_BYTES).toString("hex");
         await adminRepo.createAdminSession(
           sessionToken,
           adminUser.id,
           new Date(Date.now() + SESSION_EXPIRATION_DAYS * 24 * 60 * 60 * 1000),
+          tx,
         );
 
         return {

--- a/src/services/adminOtpService.ts
+++ b/src/services/adminOtpService.ts
@@ -18,6 +18,7 @@ const OTP_EXPIRATION_MINUTES = 10;
 const OTP_RATE_LIMIT_MAX_ATTEMPTS = 3;
 const OTP_MIN_VALUE = 100000;
 const OTP_MAX_VALUE = 999999;
+const OTP_PURPOSE = "ADMIN" as const;
 const SESSION_EXPIRATION_DAYS = 7;
 const SESSION_TOKEN_BYTES = 64;
 
@@ -45,10 +46,10 @@ export class AdminOtpService {
     try {
       const rateLimitWindowMs = OTP_EXPIRATION_MINUTES * 60 * 1000;
       const windowStartTime = new Date(Date.now() - rateLimitWindowMs);
-      const recentOtpCount = await otpRepo.countRecentOtps(email, windowStartTime);
+      const recentOtpCount = await otpRepo.countRecentOtps(email, windowStartTime, OTP_PURPOSE);
 
       if (recentOtpCount >= OTP_RATE_LIMIT_MAX_ATTEMPTS) {
-        const oldestOtp = await otpRepo.findOldestRecentOtp(email, windowStartTime);
+        const oldestOtp = await otpRepo.findOldestRecentOtp(email, windowStartTime, OTP_PURPOSE);
         const retryAfter = oldestOtp
           ? Math.ceil((oldestOtp.createdAt.getTime() + rateLimitWindowMs - Date.now()) / 1000)
           : OTP_EXPIRATION_MINUTES * 60;
@@ -62,11 +63,11 @@ export class AdminOtpService {
         };
       }
 
-      await otpRepo.deleteExpiredOtps(email);
+      await otpRepo.deleteExpiredOtps(email, OTP_PURPOSE);
 
       const code = randomInt(OTP_MIN_VALUE, OTP_MAX_VALUE + 1);
       const expiresAt = new Date(Date.now() + OTP_EXPIRATION_MINUTES * 60 * 1000);
-      await otpRepo.createOtp(email, code, expiresAt);
+      await otpRepo.createOtp(email, code, expiresAt, OTP_PURPOSE);
 
       // Only send OTP to known admin emails — unknown emails receive a generic
       // success response without an actual email being dispatched. Recording
@@ -112,7 +113,7 @@ export class AdminOtpService {
 
   async verifyOtp(email: string, code: number, logger?: Logger): Promise<AdminOtpServiceResult> {
     try {
-      const otpRecord = await otpRepo.findValidOtp(email, code);
+      const otpRecord = await otpRepo.findValidOtp(email, code, OTP_PURPOSE);
 
       if (!otpRecord) {
         logger?.warn({ msg: "Invalid or expired admin OTP", email });
@@ -120,7 +121,7 @@ export class AdminOtpService {
       }
 
       const result = await withTransaction(async (tx) => {
-        await otpRepo.deleteAllOtpsByEmail(email, tx);
+        await otpRepo.deleteAllOtpsByEmail(email, OTP_PURPOSE, tx);
 
         const adminUser = await adminRepo.findAdminUserByEmail(email, tx);
         if (!adminUser) {

--- a/src/services/adminOtpService.ts
+++ b/src/services/adminOtpService.ts
@@ -1,0 +1,181 @@
+import { randomBytes, randomInt } from "crypto";
+import { withTransaction } from "../repo/db";
+import type { EmailService } from "./email/emailService";
+import type { Logger } from "../lib/logger";
+import * as otpRepo from "../repo/otpRepo";
+import * as adminRepo from "../repo/adminRepo";
+
+/**
+ * OTP service for the admin portal.
+ *
+ * Re-uses the shared OTPCode table and rate-limiting logic, but:
+ *   - generate: only sends an email when the address belongs to an AdminUser
+ *     (non-admin emails receive the same generic response to avoid enumeration)
+ *   - verify: creates an AdminSession instead of a regular Session
+ */
+
+const OTP_EXPIRATION_MINUTES = 10;
+const OTP_RATE_LIMIT_MAX_ATTEMPTS = 3;
+const OTP_MIN_VALUE = 100000;
+const OTP_MAX_VALUE = 999999;
+const SESSION_EXPIRATION_DAYS = 7;
+const SESSION_TOKEN_BYTES = 64;
+
+export interface AdminOtpServiceResult {
+  success: boolean;
+  error?: string;
+  statusCode?: number;
+  retryAfter?: number;
+  sessionToken?: string;
+  adminUser?: {
+    id: string;
+    email: string;
+    name: string | null;
+  };
+}
+
+export class AdminOtpService {
+  private emailService: EmailService;
+
+  constructor(emailService: EmailService) {
+    this.emailService = emailService;
+  }
+
+  async requestOtp(email: string, logger?: Logger): Promise<AdminOtpServiceResult> {
+    try {
+      const rateLimitWindowMs = OTP_EXPIRATION_MINUTES * 60 * 1000;
+      const windowStartTime = new Date(Date.now() - rateLimitWindowMs);
+      const recentOtpCount = await otpRepo.countRecentOtps(email, windowStartTime);
+
+      if (recentOtpCount >= OTP_RATE_LIMIT_MAX_ATTEMPTS) {
+        const oldestOtp = await otpRepo.findOldestRecentOtp(email, windowStartTime);
+        const retryAfter = oldestOtp
+          ? Math.ceil((oldestOtp.createdAt.getTime() + rateLimitWindowMs - Date.now()) / 1000)
+          : OTP_EXPIRATION_MINUTES * 60;
+
+        logger?.warn({ msg: "Admin OTP rate limit exceeded", email, retryAfter });
+        return {
+          success: false,
+          error: "Rate limit exceeded",
+          statusCode: 429,
+          retryAfter: Math.max(retryAfter, 0),
+        };
+      }
+
+      await otpRepo.deleteExpiredOtps(email);
+
+      // Only send OTP to known admin emails — unknown emails receive a generic
+      // success response without an actual email being dispatched.
+      const adminUser = await adminRepo.findAdminUserByEmail(email);
+      if (!adminUser) {
+        logger?.info({ msg: "Admin OTP requested for non-admin email (silently ignored)", email });
+        return { success: true };
+      }
+
+      const code = randomInt(OTP_MIN_VALUE, OTP_MAX_VALUE);
+      const expiresAt = new Date(Date.now() + OTP_EXPIRATION_MINUTES * 60 * 1000);
+      await otpRepo.createOtp(email, code, expiresAt);
+
+      logger?.info({ msg: "Admin OTP generated", email, expiresIn: `${OTP_EXPIRATION_MINUTES}m` });
+
+      const emailResult = await this.emailService.sendEmail(
+        {
+          to: email,
+          subject: "Your Hello Norway Admin Login Code",
+          text: `Your admin login code is: ${code}\n\nThis code will expire in ${OTP_EXPIRATION_MINUTES} minutes.\n\nIf you didn't request this code, please ignore this email.`,
+          html: `
+            <div style="font-family: Arial, sans-serif; max-width: 600px; margin: 0 auto;">
+              <h2>Hello Norway Admin Login Code</h2>
+              <p>Your admin login code is:</p>
+              <h1 style="font-size: 32px; letter-spacing: 8px; color: #333;">${code}</h1>
+              <p>This code will expire in ${OTP_EXPIRATION_MINUTES} minutes.</p>
+              <p style="color: #666; font-size: 14px;">If you didn't request this code, please ignore this email.</p>
+            </div>
+          `,
+        },
+        logger,
+      );
+
+      if (!emailResult.success) {
+        logger?.error({ msg: "Failed to send admin OTP email", email, error: emailResult.error });
+        return { success: false, error: "Failed to send email", statusCode: 500 };
+      }
+
+      logger?.info({ msg: "Admin OTP email sent successfully", email });
+      return { success: true };
+    } catch (error) {
+      logger?.error({ msg: "Error in admin requestOtp", email, error });
+      return { success: false, error: "Internal server error", statusCode: 500 };
+    }
+  }
+
+  async verifyOtp(email: string, code: number, logger?: Logger): Promise<AdminOtpServiceResult> {
+    try {
+      const otpRecord = await otpRepo.findValidOtp(email, code);
+
+      if (!otpRecord) {
+        logger?.warn({ msg: "Invalid or expired admin OTP", email });
+        return { success: false, error: "Invalid or expired OTP", statusCode: 401 };
+      }
+
+      const result = await withTransaction(async (tx) => {
+        await otpRepo.deleteAllOtpsByEmail(email, tx);
+
+        const adminUser = await adminRepo.findAdminUserByEmail(email);
+        if (!adminUser) {
+          throw { status: 401, message: "Unauthorized" };
+        }
+
+        await adminRepo.deleteAdminUserSessions(adminUser.id);
+
+        const sessionToken = randomBytes(SESSION_TOKEN_BYTES).toString("hex");
+        await adminRepo.createAdminSession(
+          sessionToken,
+          adminUser.id,
+          new Date(Date.now() + SESSION_EXPIRATION_DAYS * 24 * 60 * 60 * 1000),
+        );
+
+        return {
+          sessionToken,
+          adminUser: {
+            id: adminUser.id,
+            email: adminUser.email,
+            name: adminUser.name,
+          },
+        };
+      });
+
+      logger?.info({ msg: "Admin OTP verified successfully", email });
+      return { success: true, ...result };
+    } catch (error: unknown) {
+      if (
+        typeof error === "object" &&
+        error !== null &&
+        "status" in error &&
+        (error as { status: number }).status === 401
+      ) {
+        return { success: false, error: "Unauthorized", statusCode: 401 };
+      }
+      logger?.error({ msg: "Error in admin verifyOtp", email, error });
+      return { success: false, error: "Internal server error", statusCode: 500 };
+    }
+  }
+}
+
+let adminOtpServiceInstance: AdminOtpService | null = null;
+
+function getAdminOtpServiceInstance(): AdminOtpService {
+  if (!adminOtpServiceInstance) {
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    const { emailService } = require("./email");
+    adminOtpServiceInstance = new AdminOtpService(emailService);
+  }
+  return adminOtpServiceInstance;
+}
+
+export const adminOtpService = {
+  requestOtp: (email: string, logger?: Logger) =>
+    getAdminOtpServiceInstance().requestOtp(email, logger),
+  verifyOtp: (email: string, code: number, logger?: Logger) =>
+    getAdminOtpServiceInstance().verifyOtp(email, code, logger),
+};

--- a/src/services/otpService.ts
+++ b/src/services/otpService.ts
@@ -17,6 +17,7 @@ const OTP_EXPIRATION_MINUTES = 10;
 const OTP_RATE_LIMIT_MAX_ATTEMPTS = 3;
 const OTP_MIN_VALUE = 100000; // 6-digit OTP minimum
 const OTP_MAX_VALUE = 999999; // 6-digit OTP maximum
+const OTP_PURPOSE = "USER" as const;
 const SESSION_EXPIRATION_DAYS = 7;
 const SESSION_TOKEN_BYTES = 64;
 
@@ -51,11 +52,11 @@ export class OtpService {
       // Check rate limiting - count OTPs created in last window
       const rateLimitWindowMs = OTP_EXPIRATION_MINUTES * 60 * 1000;
       const windowStartTime = new Date(Date.now() - rateLimitWindowMs);
-      const recentOtpCount = await otpRepo.countRecentOtps(email, windowStartTime);
+      const recentOtpCount = await otpRepo.countRecentOtps(email, windowStartTime, OTP_PURPOSE);
 
       if (recentOtpCount >= OTP_RATE_LIMIT_MAX_ATTEMPTS) {
         // Calculate retry after in seconds (time until oldest OTP expires)
-        const oldestOtp = await otpRepo.findOldestRecentOtp(email, windowStartTime);
+        const oldestOtp = await otpRepo.findOldestRecentOtp(email, windowStartTime, OTP_PURPOSE);
 
         const retryAfter = oldestOtp
           ? Math.ceil((oldestOtp.createdAt.getTime() + rateLimitWindowMs - Date.now()) / 1000)
@@ -72,14 +73,14 @@ export class OtpService {
       }
 
       // Delete expired OTP records for this email
-      await otpRepo.deleteExpiredOtps(email);
+      await otpRepo.deleteExpiredOtps(email, OTP_PURPOSE);
 
       // Generate cryptographically secure 6-digit OTP
       const code = randomInt(OTP_MIN_VALUE, OTP_MAX_VALUE);
 
       // Store OTP with configured expiration
       const expiresAt = new Date(Date.now() + OTP_EXPIRATION_MINUTES * 60 * 1000);
-      await otpRepo.createOtp(email, code, expiresAt);
+      await otpRepo.createOtp(email, code, expiresAt, OTP_PURPOSE);
 
       logger?.info({
         msg: 'OTP generated',
@@ -137,7 +138,7 @@ export class OtpService {
   async verifyOtp(email: string, code: number, logger?: Logger): Promise<OtpServiceResult> {
     try {
       // Find valid OTP for this email
-      const otpRecord = await otpRepo.findValidOtp(email, code);
+      const otpRecord = await otpRepo.findValidOtp(email, code, OTP_PURPOSE);
 
       if (!otpRecord) {
         logger?.warn({ msg: 'Invalid or expired OTP', email });
@@ -152,7 +153,7 @@ export class OtpService {
       // If any step fails, the OTP is not consumed and the user can retry
       const result = await withTransaction(async (tx) => {
         // Delete all OTP records for this email after successful verification
-        await otpRepo.deleteAllOtpsByEmail(email, tx);
+        await otpRepo.deleteAllOtpsByEmail(email, OTP_PURPOSE, tx);
 
         const user = await userRepo.upsertUserByEmail(email, tx);
 

--- a/src/types/express.d.ts
+++ b/src/types/express.d.ts
@@ -15,6 +15,16 @@ declare global {
         token: string;
         expiresAt: Date;
       };
+      adminUser?: {
+        id: string;
+        email: string;
+        name: string | null;
+      };
+      adminSession?: {
+        id: string;
+        token: string;
+        expiresAt: Date;
+      };
     }
   }
 }

--- a/tsoa.json
+++ b/tsoa.json
@@ -11,6 +11,12 @@
         "in": "cookie",
         "name": "session_token",
         "description": "Session token cookie obtained from /api/otp/verify"
+      },
+      "admin_cookie_auth": {
+        "type": "apiKey",
+        "in": "cookie",
+        "name": "admin_session_token",
+        "description": "Admin session token cookie obtained from /api/admin/otp/verify"
       }
     },
     "basePath": "/api",


### PR DESCRIPTION
Closes parts of #129.

## Summary

- **Admin OTP service** — reuses the shared `OTPCode` table and rate-limiting logic; only sends emails to known `AdminUser` addresses (non-admin emails receive the same generic response to avoid enumeration)
- **Admin session management** — issues `AdminSession` records (separate from regular `Session`); cookies use `ADMIN_SESSION_COOKIE_SECRET` so admin and user sessions are fully isolated
- **Express controllers** — `AdminOtpController` (`/api/admin/otp/{generate,verify}`) and `AdminAuthController` (`/api/admin/auth/{session,logout}`); tsoa `admin_cookie_auth` security scheme
- **Next.js API proxies** — four routes mirroring the Express endpoints, with cookie-setting on verify
- **Admin login page** — served at `/{ADMIN_PATH}/login` (configured via env var); same OTP UX as the regular login page
- **Admin dashboard placeholder** — at `/{ADMIN_PATH}/dashboard`, ready for stats work in the next phase
- **Middleware** — runtime rewrite of `/{ADMIN_PATH}/*` → `/portal/*` with inline auth check before the rewrite fires; direct `/portal` access blocked

## Test plan

- [x] Unit tests: 361/361 passing (`adminOtp.test.ts` + `adminAuth.test.ts` — 34 new tests covering happy path, rate limiting, non-admin email handling, session rotation, 401/500 error paths)
- [x] E2E tests: 80/80 passing (`admin-portal.spec.ts` — 13 new tests covering direct portal blocking, unauthenticated routing, OTP login flow, authenticated dashboard access, logout)
- [x] `npm run lint` — 0 errors
- [x] `npm run build` — clean


Made with [Cursor](https://cursor.com)